### PR TITLE
Oppdaterer .security/description.yaml og catalog-info.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.security/ @larsore

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,0 +1,4 @@
+organization: IT
+product: SKIP
+repo_types: [Service]
+platforms: [LOKALT]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "ztoperator"
+  tags:
+  - "internal"
+spec:
+  type: "service"
+  lifecycle: "production"
+  owner: "skip"


### PR DESCRIPTION
Denne PRen setter security champion i git-repoet ved å legge til \`@${sec_champ}\` i CODEOWNER-filen.
Videre opprettes description-filen under .security-mappen med følgende felter:

- \`organization: IT\`
- \`product: SKIP\`
- \`repo_types: [Service]\`
- \`platforms: [LOKALT]\`

Oppretter også \`catalog-info.yaml\` hvis den ikke finnes fra før. Dette gjør at repoet kan legges inn inn i utviklerportalen [kartverket.dev](https://kartverket.dev/).

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.