### PR TITLE
Set up continuous deploy to sandbox

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -5,20 +5,43 @@ on:
   push:
     branches: [main]
     paths-ignore:
+      - .flox/**
+      - .run/**
+      - .security/**
+      - scripts/**
+      - test/**
+      - .dockerignore
+      - .gitignore
+      - .golangci.yml
+      - .goreleaser.yaml
+      - CONTRIBUTING.md
+      - Dockerfile.goreleaser
+      - LICENSE
       - README.md
+      - catalog.info
+      - ztoperator_logo.png
   pull_request:
     branches: [main]
     paths-ignore:
+      - .flox/**
+      - .run/**
+      - .security/**
+      - scripts/**
+      - test/**
+      - .dockerignore
+      - .gitignore
+      - .golangci.yml
+      - .goreleaser.yaml
+      - CONTRIBUTING.md
+      - Dockerfile.goreleaser
+      - LICENSE
       - README.md
+      - catalog.info
+      - ztoperator_logo.png
 
 env:
-  # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
-  RBAC_FILE_PATH: config/rbac/role.yaml
-  CRD_FILE_PATH: config/crd/bases/ztoperator.kartverket.no_authpolicies.yaml
-  ARTIFACT_NAME: ztoperator-artifact-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
   build:
@@ -51,7 +74,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build-docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
           push: ${{ !github.event.pull_request.draft }}
@@ -80,42 +103,14 @@ jobs:
           image_url: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{needs.build.outputs.image_digest}}"
           tfsec: false
 
-  generate:
-    if: (!github.event.pull_request.draft)
-    name: CRD and ClusterRole
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Golang environment
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.24.3'
-
-      - name: Generate CRD and ClusterRole
-        run: make generate
-
-      - name: Upload CRD and ClusterRole
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: |
-            ${{ env.RBAC_FILE_PATH }}
-            ${{ env.CRD_APP_FILE_PATH }}
-            ${{ env.CRD_JOB_FILE_PATH }}
-            ${{ env.CRD_ROUTING_FILE_PATH }}
-
   deploy-argo:
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch')
-    needs: [build, generate]
+    if: ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main')
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       id-token: write
     steps:
-      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
         id: octo-sts
         with:
           scope: kartverket/tilgangsstyring-apps
@@ -135,7 +130,7 @@ jobs:
       - name: Commit Changes to Repo
         run: |
           git config --global user.email "noreply@kartverket.no"
-          git config --global user.name "Ztoperator Actions"
+          git config --global user.name "Ztoperator Deploy Action"
           git commit -aF- <<EOF
           ztoperator ${{ github.ref_name }}[${{ github.event.after }}]: ${{ github.event.head_commit.message }}
           EOF

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -124,8 +124,8 @@ jobs:
 
       - name: Patch Image Digest
         run: |
-          echo "\"${{ needs.build.outputs.image_digest }}\"" > "env/atgcp1-sandbox/ztoperator-system/tag"
-          echo "\"${{ needs.build.outputs.image_digest }}\"" > "env/atkv3-sandbox/ztoperator-system/tag"
+          echo "\"${{ needs.build.outputs.image_digest }}\"" > "env/atgcp1-sandbox/ztoperator-system/digest"
+          echo "\"${{ needs.build.outputs.image_digest }}\"" > "env/atkv3-sandbox/ztoperator-system/digest"
 
       - name: Commit Changes to Repo
         run: |

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -79,85 +79,65 @@ jobs:
         with:
           image_url: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{needs.build.outputs.image_digest}}"
           tfsec: false
-#
-#  generate:
-#    if: (!github.event.pull_request.draft)
-#    name: CRD and ClusterRole
-#    runs-on: ubuntu-latest
-#    permissions:
-#      contents: read
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@v4
-#
-#      - name: Setup Golang environment
-#        uses: actions/setup-go@v5
-#        with:
-#          go-version: '1.23.1'
-#
-#      - name: Generate CRD and ClusterRole
-#        run: make generate
-#
-#      - name: Upload CRD and ClusterRole
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: ${{ env.ARTIFACT_NAME }}
-#          path: |
-#            ${{ env.RBAC_FILE_PATH }}
-#            ${{ env.CRD_APP_FILE_PATH }}
-#            ${{ env.CRD_JOB_FILE_PATH }}
-#            ${{ env.CRD_ROUTING_FILE_PATH }}
-#
-#  deploy-argo:
-#    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch')
-#    needs: [build, generate]
-#    runs-on: ubuntu-latest
-#    permissions:
-#      id-token: write
-#    env:
-#      BASE_DIR: ./bases/ztoperator-latest
-#      TMP_FILE: tmp_kustomization.yaml
-#    steps:
-#      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
-#        id: octo-sts
-#        with:
-#          scope: kartverket/skip-apps
-#          identity: ztoperator
-#
-#      - name: Checkout apps repo
-#        uses: actions/checkout@v4
-#        with:
-#          repository: kartverket/skip-apps
-#          token: ${{ steps.octo-sts.outputs.token }}
-#
-#      - name: Download CRD and RBAC
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: ${{ env.ARTIFACT_NAME }}
-#          path: config/
-#
-#      - name: Patch Image Digest
-#        run: |
-#          kubectl patch --type=merge --local \
-#            -f $BASE_DIR/kustomization.yaml \
-#            -p '{"images":[{"name":"${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}","digest":"${{needs.build.outputs.image_digest}}"}]}' \
-#            -o yaml > $BASE_DIR/$TMP_FILE
-#
-#          rm $BASE_DIR/kustomization.yaml
-#          mv $BASE_DIR/$TMP_FILE $BASE_DIR/kustomization.yaml
-#
-#      - name: Update CRD and Role
-#        run: |
-#          cp -f -v $CRD_APP_FILE_PATH $BASE_DIR/crd.yaml
-#          cp -f -v $RBAC_FILE_PATH $BASE_DIR/clusterrole.yaml
-#          rm -rf config/
-#
-#      - name: Commit Changes to Repo
-#        run: |
-#          git config --global user.email "noreply@kartverket.no"
-#          git config --global user.name "GitHub Actions"
-#          git commit -aF- <<EOF
-#          ztoperator ${{ github.ref_name }}[${{ github.event.after }}]: ${{ github.event.head_commit.message }}
-#          EOF
-#
-#          git push
+
+  generate:
+    if: (!github.event.pull_request.draft)
+    name: CRD and ClusterRole
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Golang environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.3'
+
+      - name: Generate CRD and ClusterRole
+        run: make generate
+
+      - name: Upload CRD and ClusterRole
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: |
+            ${{ env.RBAC_FILE_PATH }}
+            ${{ env.CRD_APP_FILE_PATH }}
+            ${{ env.CRD_JOB_FILE_PATH }}
+            ${{ env.CRD_ROUTING_FILE_PATH }}
+
+  deploy-argo:
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch')
+    needs: [build, generate]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
+        with:
+          scope: kartverket/tilgangsstyring-apps
+          identity: ztoperator
+
+      - name: Checkout apps repo
+        uses: actions/checkout@v4
+        with:
+          repository: kartverket/tilgangsstyring-apps
+          token: ${{ steps.octo-sts.outputs.token }}
+
+      - name: Patch Image Digest
+        run: |
+          echo "\"${{ needs.build.outputs.image_digest }}\"" > "env/atgcp1-sandbox/ztoperator-system/tag"
+          echo "\"${{ needs.build.outputs.image_digest }}\"" > "env/atkv3-sandbox/ztoperator-system/tag"
+
+      - name: Commit Changes to Repo
+        run: |
+          git config --global user.email "noreply@kartverket.no"
+          git config --global user.name "Ztoperator Actions"
+          git commit -aF- <<EOF
+          ztoperator ${{ github.ref_name }}[${{ github.event.after }}]: ${{ github.event.head_commit.message }}
+          EOF
+
+          git push

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,7 +74,7 @@ func main() {
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 		Level:       zapcore.Level(-1),
 	}
 	opts.BindFlags(flag.CommandLine)


### PR DESCRIPTION
This PR updates build-and-deploy.yaml to update tilgangsstyring-apps with the latest image-digest after pushing to main. It also switches to json-logging.

I am unsure about whether to inculde the generate job in the workflow or not. 