### PR TITLE
Watch secrets and configmaps

### DIFF
--- a/internal/controller/authpolicy_controller.go
+++ b/internal/controller/authpolicy_controller.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 
 	ztoperatorv1alpha1 "github.com/kartverket/ztoperator/api/v1alpha1"
+	"github.com/kartverket/ztoperator/internal/eventhandler/configmap"
 	"github.com/kartverket/ztoperator/internal/eventhandler/pod"
+	"github.com/kartverket/ztoperator/internal/eventhandler/secret"
 	"github.com/kartverket/ztoperator/internal/reconciler"
 	"github.com/kartverket/ztoperator/internal/resolver"
 	"github.com/kartverket/ztoperator/internal/state"
@@ -46,6 +48,8 @@ func (r *AuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&v1alpha4.EnvoyFilter{}).
 		Owns(&v1.Secret{}).
 		Watches(&v1.Pod{}, pod.EventHandler(r.Client)).
+		Watches(&v1.Secret{}, secret.EventHandler(r.Client)).
+		Watches(&v1.ConfigMap{}, configmap.EventHandler(r.Client)).
 		Complete(r)
 }
 

--- a/internal/eventhandler/configmap/event_handler.go
+++ b/internal/eventhandler/configmap/event_handler.go
@@ -1,0 +1,27 @@
+package configmap
+
+import (
+	"context"
+
+	"github.com/kartverket/ztoperator/internal/eventhandler"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func EventHandler(c client.Client) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+		configMap, ok := obj.(*corev1.ConfigMap)
+		if !ok {
+			return nil
+		}
+
+		// Owned configmaps already trigger reconcile
+		if eventhandler.IsOwnedByAuthPolicy(configMap) {
+			return nil
+		}
+
+		return eventhandler.EnqueueAuthPoliciesInNamespace(ctx, c, configMap.Namespace)
+	})
+}

--- a/internal/eventhandler/configmap/event_handler_test.go
+++ b/internal/eventhandler/configmap/event_handler_test.go
@@ -1,0 +1,163 @@
+package configmap_test
+
+import (
+	"context"
+	"testing"
+
+	ztoperatorv1alpha1 "github.com/kartverket/ztoperator/api/v1alpha1"
+	"github.com/kartverket/ztoperator/internal/eventhandler/configmap"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestConfigMapEventHandler_WithNonConfigMapObject_ReturnsNoRequests(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Arrange
+	k8sClient := createFakeClientForConfigMapHandler()
+	h := configmap.EventHandler(k8sClient)
+	queue := workqueue.NewTypedRateLimitingQueue[reconcile.Request](workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer queue.ShutDown()
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "some-secret", Namespace: "default"},
+	}
+
+	// 2. Act
+	h.Create(ctx, event.CreateEvent{Object: secret}, queue)
+
+	// 3. Assert
+	assert.Equal(t, 0, queue.Len(), "Expected no reconcile requests for non-configmap object")
+}
+
+func TestConfigMapEventHandler_WithConfigMapOwnedByAuthPolicy_ReturnsNoRequests(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Arrange
+	k8sClient := createFakeClientForConfigMapHandler()
+	h := configmap.EventHandler(k8sClient)
+	queue := workqueue.NewTypedRateLimitingQueue[reconcile.Request](workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer queue.ShutDown()
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "owned-configmap",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "ztoperator.kartverket.no/v1alpha1",
+					Kind:       "AuthPolicy",
+					Name:       "my-auth-policy",
+				},
+			},
+		},
+	}
+
+	// 2. Act
+	h.Create(ctx, event.CreateEvent{Object: cm}, queue)
+
+	// 3. Assert
+	assert.Equal(t, 0, queue.Len(), "Expected no reconcile requests for ConfigMap owned by AuthPolicy")
+}
+
+func TestConfigMapEventHandler_WithConfigMapInNamespaceWithNoAuthPolicies_ReturnsNoRequests(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Arrange
+	k8sClient := createFakeClientForConfigMapHandler()
+	h := configmap.EventHandler(k8sClient)
+	queue := workqueue.NewTypedRateLimitingQueue[reconcile.Request](workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer queue.ShutDown()
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-configmap", Namespace: "default"},
+	}
+
+	// 2. Act
+	h.Create(ctx, event.CreateEvent{Object: cm}, queue)
+
+	// 3. Assert
+	assert.Equal(t, 0, queue.Len(), "Expected no reconcile requests when no AuthPolicies exist in namespace")
+}
+
+func TestConfigMapEventHandler_WithConfigMapInNamespaceWithAuthPolicies_ReturnsRequestForEachAuthPolicy(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Arrange
+	authPolicy1 := &ztoperatorv1alpha1.AuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-one", Namespace: "default"},
+	}
+	authPolicy2 := &ztoperatorv1alpha1.AuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-two", Namespace: "default"},
+	}
+	k8sClient := createFakeClientForConfigMapHandler(authPolicy1, authPolicy2)
+	h := configmap.EventHandler(k8sClient)
+	queue := workqueue.NewTypedRateLimitingQueue[reconcile.Request](workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer queue.ShutDown()
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-configmap", Namespace: "default"},
+	}
+
+	// 2. Act
+	h.Create(ctx, event.CreateEvent{Object: cm}, queue)
+
+	// 3. Assert
+	requests := drainQueue(queue)
+	assert.Len(t, requests, 2)
+	assert.Contains(t, requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: "policy-one", Namespace: "default"}})
+	assert.Contains(t, requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: "policy-two", Namespace: "default"}})
+}
+
+func TestConfigMapEventHandler_WithConfigMapInNamespace_DoesNotEnqueueAuthPoliciesFromOtherNamespaces(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Arrange
+	authPolicyInSameNamespace := &ztoperatorv1alpha1.AuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "same-namespace-policy", Namespace: "default"},
+	}
+	authPolicyInOtherNamespace := &ztoperatorv1alpha1.AuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-namespace-policy", Namespace: "other"},
+	}
+	k8sClient := createFakeClientForConfigMapHandler(authPolicyInSameNamespace, authPolicyInOtherNamespace)
+	h := configmap.EventHandler(k8sClient)
+	queue := workqueue.NewTypedRateLimitingQueue[reconcile.Request](workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer queue.ShutDown()
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-configmap", Namespace: "default"},
+	}
+
+	// 2. Act
+	h.Create(ctx, event.CreateEvent{Object: cm}, queue)
+
+	// 3. Assert
+	requests := drainQueue(queue)
+	assert.Len(t, requests, 1)
+	assert.Contains(t, requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: "same-namespace-policy", Namespace: "default"}})
+}
+
+func createFakeClientForConfigMapHandler(objects ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = ztoperatorv1alpha1.AddToScheme(scheme)
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func drainQueue(queue workqueue.TypedRateLimitingInterface[reconcile.Request]) []reconcile.Request {
+	var requests []reconcile.Request
+	for queue.Len() > 0 {
+		item, _ := queue.Get()
+		requests = append(requests, item)
+		queue.Done(item)
+	}
+	return requests
+}

--- a/internal/eventhandler/eventhandler.go
+++ b/internal/eventhandler/eventhandler.go
@@ -1,0 +1,54 @@
+package eventhandler
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	authPolicyGroup   = "ztoperator.kartverket.no"
+	authPolicyVersion = "v1alpha1"
+	authPolicyKind    = "AuthPolicy"
+)
+
+// IsOwnedByAuthPolicy returns true if the object has an owner reference pointing to an AuthPolicy.
+func IsOwnedByAuthPolicy(obj client.Object) bool {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.APIVersion == authPolicyGroup+"/"+authPolicyVersion && ref.Kind == authPolicyKind {
+			return true
+		}
+	}
+	return false
+}
+
+// EnqueueAuthPoliciesInNamespace lists all AuthPolicy resources in the given namespace
+// and returns a reconcile request for each one.
+func EnqueueAuthPoliciesInNamespace(ctx context.Context, c client.Client, namespace string) []reconcile.Request {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   authPolicyGroup,
+		Version: authPolicyVersion,
+		Kind:    authPolicyKind + "List",
+	})
+
+	if err := c.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return nil
+	}
+
+	reqs := make([]reconcile.Request, 0, len(list.Items))
+	for _, item := range list.Items {
+		reqs = append(reqs, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: item.GetNamespace(),
+				Name:      item.GetName(),
+			},
+		})
+	}
+
+	return reqs
+}

--- a/internal/eventhandler/pod/event_handler.go
+++ b/internal/eventhandler/pod/event_handler.go
@@ -3,10 +3,8 @@ package pod
 import (
 	"context"
 
+	"github.com/kartverket/ztoperator/internal/eventhandler"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -19,27 +17,6 @@ func EventHandler(c client.Client) handler.EventHandler {
 			return nil
 		}
 
-		list := &unstructured.UnstructuredList{}
-		list.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "ztoperator.kartverket.no",
-			Version: "v1alpha1",
-			Kind:    "AuthPolicyList",
-		})
-
-		if err := c.List(ctx, list, client.InNamespace(pod.Namespace)); err != nil {
-			return nil
-		}
-
-		reqs := make([]reconcile.Request, 0, len(list.Items))
-		for _, item := range list.Items {
-			reqs = append(reqs, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: item.GetNamespace(),
-					Name:      item.GetName(),
-				},
-			})
-		}
-
-		return reqs
+		return eventhandler.EnqueueAuthPoliciesInNamespace(ctx, c, pod.Namespace)
 	})
 }

--- a/internal/eventhandler/pod/event_handler_test.go
+++ b/internal/eventhandler/pod/event_handler_test.go
@@ -1,0 +1,133 @@
+package pod_test
+
+import (
+	"context"
+	"testing"
+
+	ztoperatorv1alpha1 "github.com/kartverket/ztoperator/api/v1alpha1"
+	"github.com/kartverket/ztoperator/internal/eventhandler/pod"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestEventHandler_WithNonPodObject_ReturnsNoRequests(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Arrange
+	k8sClient := createFakeClientForPodHandler()
+	h := pod.EventHandler(k8sClient)
+	queue := workqueue.NewTypedRateLimitingQueue[reconcile.Request](workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer queue.ShutDown()
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "some-configmap", Namespace: "default"},
+	}
+
+	// 2. Act
+	h.Create(ctx, event.CreateEvent{Object: configMap}, queue)
+
+	// 3. Assert
+	assert.Equal(t, 0, queue.Len(), "Expected no reconcile requests for non-pod object")
+}
+
+func TestEventHandler_WithPodInNamespaceWithNoAuthPolicies_ReturnsNoRequests(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Arrange
+	k8sClient := createFakeClientForPodHandler()
+	h := pod.EventHandler(k8sClient)
+	queue := workqueue.NewTypedRateLimitingQueue[reconcile.Request](workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer queue.ShutDown()
+
+	p := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+	}
+
+	// 2. Act
+	h.Create(ctx, event.CreateEvent{Object: p}, queue)
+
+	// 3. Assert
+	assert.Equal(t, 0, queue.Len(), "Expected no reconcile requests when no AuthPolicies exist in namespace")
+}
+
+func TestEventHandler_WithPodInNamespaceWithAuthPolicies_ReturnsRequestForEachAuthPolicy(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Arrange
+	authPolicy1 := &ztoperatorv1alpha1.AuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-one", Namespace: "default"},
+	}
+	authPolicy2 := &ztoperatorv1alpha1.AuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-two", Namespace: "default"},
+	}
+	k8sClient := createFakeClientForPodHandler(authPolicy1, authPolicy2)
+	h := pod.EventHandler(k8sClient)
+	queue := workqueue.NewTypedRateLimitingQueue[reconcile.Request](workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer queue.ShutDown()
+
+	p := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+	}
+
+	// 2. Act
+	h.Create(ctx, event.CreateEvent{Object: p}, queue)
+
+	// 3. Assert
+	requests := drainQueue(queue)
+	assert.Len(t, requests, 2)
+	assert.Contains(t, requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: "policy-one", Namespace: "default"}})
+	assert.Contains(t, requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: "policy-two", Namespace: "default"}})
+}
+
+func TestEventHandler_WithPodInNamespace_DoesNotEnqueueAuthPoliciesFromOtherNamespaces(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Arrange
+	authPolicyInSameNamespace := &ztoperatorv1alpha1.AuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "same-namespace-policy", Namespace: "default"},
+	}
+	authPolicyInOtherNamespace := &ztoperatorv1alpha1.AuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-namespace-policy", Namespace: "other"},
+	}
+	k8sClient := createFakeClientForPodHandler(authPolicyInSameNamespace, authPolicyInOtherNamespace)
+	h := pod.EventHandler(k8sClient)
+	queue := workqueue.NewTypedRateLimitingQueue[reconcile.Request](workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer queue.ShutDown()
+
+	p := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+	}
+
+	// 2. Act
+	h.Create(ctx, event.CreateEvent{Object: p}, queue)
+
+	// 3. Assert
+	requests := drainQueue(queue)
+	assert.Len(t, requests, 1)
+	assert.Contains(t, requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: "same-namespace-policy", Namespace: "default"}})
+}
+
+func createFakeClientForPodHandler(objects ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = ztoperatorv1alpha1.AddToScheme(scheme)
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func drainQueue(queue workqueue.TypedRateLimitingInterface[reconcile.Request]) []reconcile.Request {
+	var requests []reconcile.Request
+	for queue.Len() > 0 {
+		item, _ := queue.Get()
+		requests = append(requests, item)
+		queue.Done(item)
+	}
+	return requests
+}

--- a/internal/eventhandler/secret/event_handler.go
+++ b/internal/eventhandler/secret/event_handler.go
@@ -1,0 +1,27 @@
+package secret
+
+import (
+	"context"
+
+	"github.com/kartverket/ztoperator/internal/eventhandler"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func EventHandler(c client.Client) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+		secret, ok := obj.(*corev1.Secret)
+		if !ok {
+			return nil
+		}
+
+		// Owned secrets already trigger reconcile
+		if eventhandler.IsOwnedByAuthPolicy(secret) {
+			return nil
+		}
+
+		return eventhandler.EnqueueAuthPoliciesInNamespace(ctx, c, secret.Namespace)
+	})
+}

--- a/internal/eventhandler/secret/event_handler_test.go
+++ b/internal/eventhandler/secret/event_handler_test.go
@@ -1,0 +1,163 @@
+package secret_test
+
+import (
+	"context"
+	"testing"
+
+	ztoperatorv1alpha1 "github.com/kartverket/ztoperator/api/v1alpha1"
+	"github.com/kartverket/ztoperator/internal/eventhandler/secret"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestSecretEventHandler_WithNonSecretObject_ReturnsNoRequests(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Arrange
+	k8sClient := createFakeClientForSecretHandler()
+	h := secret.EventHandler(k8sClient)
+	queue := workqueue.NewTypedRateLimitingQueue[reconcile.Request](workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer queue.ShutDown()
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "some-configmap", Namespace: "default"},
+	}
+
+	// 2. Act
+	h.Create(ctx, event.CreateEvent{Object: cm}, queue)
+
+	// 3. Assert
+	assert.Equal(t, 0, queue.Len(), "Expected no reconcile requests for non-secret object")
+}
+
+func TestSecretEventHandler_WithSecretOwnedByAuthPolicy_ReturnsNoRequests(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Arrange
+	k8sClient := createFakeClientForSecretHandler()
+	h := secret.EventHandler(k8sClient)
+	queue := workqueue.NewTypedRateLimitingQueue[reconcile.Request](workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer queue.ShutDown()
+
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "owned-secret",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "ztoperator.kartverket.no/v1alpha1",
+					Kind:       "AuthPolicy",
+					Name:       "my-auth-policy",
+				},
+			},
+		},
+	}
+
+	// 2. Act
+	h.Create(ctx, event.CreateEvent{Object: s}, queue)
+
+	// 3. Assert
+	assert.Equal(t, 0, queue.Len(), "Expected no reconcile requests for Secret owned by AuthPolicy")
+}
+
+func TestSecretEventHandler_WithSecretInNamespaceWithNoAuthPolicies_ReturnsNoRequests(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Arrange
+	k8sClient := createFakeClientForSecretHandler()
+	h := secret.EventHandler(k8sClient)
+	queue := workqueue.NewTypedRateLimitingQueue[reconcile.Request](workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer queue.ShutDown()
+
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: "default"},
+	}
+
+	// 2. Act
+	h.Create(ctx, event.CreateEvent{Object: s}, queue)
+
+	// 3. Assert
+	assert.Equal(t, 0, queue.Len(), "Expected no reconcile requests when no AuthPolicies exist in namespace")
+}
+
+func TestSecretEventHandler_WithSecretInNamespaceWithAuthPolicies_ReturnsRequestForEachAuthPolicy(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Arrange
+	authPolicy1 := &ztoperatorv1alpha1.AuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-one", Namespace: "default"},
+	}
+	authPolicy2 := &ztoperatorv1alpha1.AuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-two", Namespace: "default"},
+	}
+	k8sClient := createFakeClientForSecretHandler(authPolicy1, authPolicy2)
+	h := secret.EventHandler(k8sClient)
+	queue := workqueue.NewTypedRateLimitingQueue[reconcile.Request](workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer queue.ShutDown()
+
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: "default"},
+	}
+
+	// 2. Act
+	h.Create(ctx, event.CreateEvent{Object: s}, queue)
+
+	// 3. Assert
+	requests := drainQueue(queue)
+	assert.Len(t, requests, 2)
+	assert.Contains(t, requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: "policy-one", Namespace: "default"}})
+	assert.Contains(t, requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: "policy-two", Namespace: "default"}})
+}
+
+func TestSecretEventHandler_WithSecretInNamespace_DoesNotEnqueueAuthPoliciesFromOtherNamespaces(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Arrange
+	authPolicyInSameNamespace := &ztoperatorv1alpha1.AuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "same-namespace-policy", Namespace: "default"},
+	}
+	authPolicyInOtherNamespace := &ztoperatorv1alpha1.AuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-namespace-policy", Namespace: "other"},
+	}
+	k8sClient := createFakeClientForSecretHandler(authPolicyInSameNamespace, authPolicyInOtherNamespace)
+	h := secret.EventHandler(k8sClient)
+	queue := workqueue.NewTypedRateLimitingQueue[reconcile.Request](workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer queue.ShutDown()
+
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: "default"},
+	}
+
+	// 2. Act
+	h.Create(ctx, event.CreateEvent{Object: s}, queue)
+
+	// 3. Assert
+	requests := drainQueue(queue)
+	assert.Len(t, requests, 1)
+	assert.Contains(t, requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: "same-namespace-policy", Namespace: "default"}})
+}
+
+func createFakeClientForSecretHandler(objects ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = ztoperatorv1alpha1.AddToScheme(scheme)
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func drainQueue(queue workqueue.TypedRateLimitingInterface[reconcile.Request]) []reconcile.Request {
+	var requests []reconcile.Request
+	for queue.Len() > 0 {
+		item, _ := queue.Get()
+		requests = append(requests, item)
+		queue.Done(item)
+	}
+	return requests
+}

--- a/test/chainsaw/authpolicy/accepted_resources/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/accepted_resources/chainsaw-test.yaml
@@ -21,7 +21,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/audience_update_triggers_reconcile/assert-after-configmap-update.yaml
+++ b/test/chainsaw/authpolicy/audience_update_triggers_reconcile/assert-after-configmap-update.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: auth-policy
+spec:
+  jwtRules:
+    - audiences:
+        - audience-v2
+        - secret-audience-v1
+      forwardOriginalToken: true
+      issuer: http://mock-oauth2.auth:8080/entraid
+      jwksUri: http://mock-oauth2.auth:8080/entraid/jwks
+  selector:
+    matchLabels:
+      app: application
+

--- a/test/chainsaw/authpolicy/audience_update_triggers_reconcile/assert-after-secret-update.yaml
+++ b/test/chainsaw/authpolicy/audience_update_triggers_reconcile/assert-after-secret-update.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: auth-policy
+spec:
+  jwtRules:
+    - audiences:
+        - audience-v2
+        - secret-audience-v2
+      forwardOriginalToken: true
+      issuer: http://mock-oauth2.auth:8080/entraid
+      jwksUri: http://mock-oauth2.auth:8080/entraid/jwks
+  selector:
+    matchLabels:
+      app: application
+

--- a/test/chainsaw/authpolicy/audience_update_triggers_reconcile/assert-initial.yaml
+++ b/test/chainsaw/authpolicy/audience_update_triggers_reconcile/assert-initial.yaml
@@ -1,0 +1,24 @@
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: auth-policy
+spec:
+  jwtRules:
+    - audiences:
+        - audience-v1
+        - secret-audience-v1
+      forwardOriginalToken: true
+      issuer: http://mock-oauth2.auth:8080/entraid
+      jwksUri: http://mock-oauth2.auth:8080/entraid/jwks
+  selector:
+    matchLabels:
+      app: application
+---
+apiVersion: ztoperator.kartverket.no/v1alpha1
+kind: AuthPolicy
+metadata:
+  name: auth-policy
+status:
+  phase: Ready
+  ready: true
+

--- a/test/chainsaw/authpolicy/audience_update_triggers_reconcile/authpolicy.yaml
+++ b/test/chainsaw/authpolicy/audience_update_triggers_reconcile/authpolicy.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: audience-configmap
+data:
+  AUDIENCE: "audience-v1"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: audience-secret
+type: Opaque
+data:
+  AUDIENCE: c2VjcmV0LWF1ZGllbmNlLXYx  # secret-audience-v1
+---
+apiVersion: ztoperator.kartverket.no/v1alpha1
+kind: AuthPolicy
+metadata:
+  name: auth-policy
+spec:
+  enabled: true
+  allowedAudiences:
+    - valueFrom:
+        configMapKeyRef:
+          name: audience-configmap
+          key: AUDIENCE
+    - valueFrom:
+        secretKeyRef:
+          name: audience-secret
+          key: AUDIENCE
+  wellKnownURI: http://mock-oauth2.auth:8080/entraid/.well-known/openid-configuration
+  selector:
+    matchLabels:
+      app: application
+

--- a/test/chainsaw/authpolicy/audience_update_triggers_reconcile/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/audience_update_triggers_reconcile/chainsaw-test.yaml
@@ -1,0 +1,29 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: audience-update-triggers-reconcile
+spec:
+  skip: false
+  concurrent: true
+  skipDelete: false
+  namespaceTemplate:
+    metadata:
+      labels:
+        istio-injection: enabled
+  steps:
+    - try:
+        - create:
+            file: ../../../resources/skiperator/application.yaml
+        - create:
+            file: authpolicy.yaml
+        - assert:
+            file: assert-initial.yaml
+        - update:
+            file: configmap-updated.yaml
+        - assert:
+            file: assert-after-configmap-update.yaml
+        - update:
+            file: secret-updated.yaml
+        - assert:
+            file: assert-after-secret-update.yaml
+

--- a/test/chainsaw/authpolicy/audience_update_triggers_reconcile/configmap-updated.yaml
+++ b/test/chainsaw/authpolicy/audience_update_triggers_reconcile/configmap-updated.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: audience-configmap
+data:
+  AUDIENCE: "audience-v2"
+

--- a/test/chainsaw/authpolicy/audience_update_triggers_reconcile/secret-updated.yaml
+++ b/test/chainsaw/authpolicy/audience_update_triggers_reconcile/secret-updated.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: audience-secret
+type: Opaque
+data:
+  AUDIENCE: c2VjcmV0LWF1ZGllbmNlLXYy  # secret-audience-v2
+

--- a/test/chainsaw/authpolicy/auto_login_authorization_header_pass_through/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/auto_login_authorization_header_pass_through/chainsaw-test.yaml
@@ -22,7 +22,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/auto_login_callback_path/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/auto_login_callback_path/chainsaw-test.yaml
@@ -21,7 +21,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/auto_login_ignore_auth_on_root/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/auto_login_ignore_auth_on_root/chainsaw-test.yaml
@@ -21,7 +21,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/auto_login_overlapping_rules/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/auto_login_overlapping_rules/chainsaw-test.yaml
@@ -21,7 +21,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/auto_login_post_logout_redirect_uri/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/auto_login_post_logout_redirect_uri/chainsaw-test.yaml
@@ -22,7 +22,7 @@ spec:
         - create:
             file: authpolicy-with-post-logout-redirect.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/auto_login_rp_initiated_logout/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/auto_login_rp_initiated_logout/chainsaw-test.yaml
@@ -21,7 +21,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/auto_login_saas/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/auto_login_saas/chainsaw-test.yaml
@@ -21,7 +21,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/auto_login_saas_match_any_suffix/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/auto_login_saas_match_any_suffix/chainsaw-test.yaml
@@ -21,7 +21,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/auto_login_spa/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/auto_login_spa/chainsaw-test.yaml
@@ -21,7 +21,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/auto_login_with_login_params/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/auto_login_with_login_params/chainsaw-test.yaml
@@ -22,7 +22,7 @@ spec:
         - create:
             file: authpolicy-acr-values.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long --insecure --test test-acr-values.hurl

--- a/test/chainsaw/authpolicy/baseline_auth_with_auth_rules/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/baseline_auth_with_auth_rules/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/baseline_auth_with_multiple_claims_different_keys/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/baseline_auth_with_multiple_claims_different_keys/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/baseline_auth_with_multiple_claims_same_key/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/baseline_auth_with_multiple_claims_same_key/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/baseline_auth_with_single_claim_multiple_values/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/baseline_auth_with_single_claim_multiple_values/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/multiple_when_claims/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/multiple_when_claims/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/one_provider/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/one_provider/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/only_authentication/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/only_authentication/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/only_ignore_auth_rules/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/only_ignore_auth_rules/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/overlapping_authrules/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/overlapping_authrules/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/paths-with-hyphen/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/paths-with-hyphen/chainsaw-test.yaml
@@ -21,7 +21,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \

--- a/test/chainsaw/authpolicy/pod_annotation_validation/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/pod_annotation_validation/chainsaw-test.yaml
@@ -19,18 +19,18 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 5
+            content: sleep 14
         - assert:
             file: application-without-pod-annotations-assert.yaml
         - apply:
             file: application-with-wrong-pod-annotations.yaml
         - script:
-            content: sleep 5
+            content: sleep 14
         - assert:
             file: application-with-wrong-pod-annotations-assert.yaml
         - apply:
             file: ../../../resources/skiperator/application-with-istio-mount.yaml
         - script:
-            content: sleep 5
+            content: sleep 14
         - assert:
             file: application-with-correct-pod-annotations-assert.yaml

--- a/test/chainsaw/authpolicy/smapi/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/smapi/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
         - create:
             file: authpolicy.yaml
         - script:
-            content: sleep 7
+            content: sleep 14
         - script:
             content: |
               hurl --error-format long \


### PR DESCRIPTION
[Refactor event_handler for reuse when adding addition handlers](https://github.com/kartverket/ztoperator/commit/2448af96367c318ec0e73b872eb2c2ecd7b21372) 
We want to add similar handlers for secrets and configmaps. First, I refactor the existing handler with some reusable logic. Tests are added first to ensure logic before and after refactor are identical.

[Watch secrets and configmaps](https://github.com/kartverket/ztoperator/commit/b98119d16c0f038d3710d5f7bfaa1626187f7f2e) 
If a secret or configmap is updated, we want a reconcile for the corresponding auth policy resource to be triggered. Such resources are typically created by other CRDs, for instance secrets from AzureAdApplication / Azurerator. These are not owned by the AuthPolicy, and so reconcile must be triggered through watch.

Triggering reconcile both through own and watch would cause double reconcile for the secrets and/or configmaps Ztoperator creates. Therefore, we ignore these in the event handlers.