### PR TITLE
Perform pharos scan on main

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -88,7 +88,7 @@ jobs:
       image_digest: ${{ steps.build-docker.outputs.digest }}
 
   pharos-scan:
-    if: (!github.event.pull_request.draft && github.ref != 'refs/heads/main')
+    if: (!github.event.pull_request.draft)
     name: Run Pharos Security Scan
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
I believe the code scanning tool for github works so that only scans performed on merges to the main branch actually result in alerts, unless the trivy category is specified. The code scanning configuration on github has not been updated since January 23th when this chance was made.