### PR TITLE
Pin cosign-release to v2

### DIFF
--- a/.github/workflows/release-version.yaml
+++ b/.github/workflows/release-version.yaml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        with:
+          cosign-release: 2.6.1
 
       - name: Install Syft for SBOM Generation
         shell: bash


### PR DESCRIPTION
cosign-installer v4 uses cosign v3. There are breaking changes from cosign v2 to v3 that prevents us from releasing. Pinning to cosign v2 temporarly.