### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Checklist
+- [ ] Commits follow best practice git conventions
+- [ ] Introduced dependencies are reviewed
+- [ ] Test coverage is adequate
+- [ ] New features are documented on `skip.kartverket.no`
+- [ ] Changes to CRD are documented on `skip.kartverket.no`
+- [ ] `setup-skip-action` and `test-authpolicy-action` are compatible with changes
+
+## Description


### PR DESCRIPTION
We find that we sometimes either break functionality (especially setup-skip-action) or forget to document new features/spec changes. This pull request template is supposed to act as a quick and non-annoying reminder.