### PR TITLE
Reduce reconcile loops by adding generation predicate

### DIFF
--- a/internal/controller/authpolicy_controller.go
+++ b/internal/controller/authpolicy_controller.go
@@ -27,7 +27,9 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -42,7 +44,10 @@ type AuthPolicyReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *AuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&ztoperatorv1alpha1.AuthPolicy{}).
+		For(
+			&ztoperatorv1alpha1.AuthPolicy{},
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
 		Owns(&istioclientsecurityv1.RequestAuthentication{}).
 		Owns(&istioclientsecurityv1.AuthorizationPolicy{}).
 		Owns(&v1alpha4.EnvoyFilter{}).


### PR DESCRIPTION
## Checklist
- [x] Commits follow best practice git conventions
- [x] Introduced dependencies are reviewed
- [x] Test coverage is adequate
- [x] New features are documented on `skip.kartverket.no`
- [x] Changes to CRD are documented on `skip.kartverket.no`
- [x] `setup-skip-action` and `test-authpolicy-action` are compatible with changes

## Description
Introduce a predicate for enqueuing reconcile requests for AuthPolicies by only enqueuing requests when `metadata.generation` changes. We do this to decrease the number of reconcile loops that occur when reconciling an AUthPolicy.