### PR TITLE
Expand chainsaw test for output claims to headers

### DIFF
--- a/test/chainsaw/authpolicy/output_claims_to_headers/authpolicy.yaml
+++ b/test/chainsaw/authpolicy/output_claims_to_headers/authpolicy.yaml
@@ -11,6 +11,8 @@ spec:
       header: x-token-role
     - claim: aud
       header: x-token-aud
+    - claim: doesntexist
+      header: x-not-in-token-but-in-output-claims
   allowedAudiences:
     - value: maskinporten_client
     - value: maskinporten_server

--- a/test/chainsaw/authpolicy/output_claims_to_headers/tests.hurl
+++ b/test/chainsaw/authpolicy/output_claims_to_headers/tests.hurl
@@ -6,6 +6,9 @@ HTTP 403
 # --- Expecting 200
 GET https://127.0.0.1:8443/random/path
 Host: foo.bar
+x-token-sub: should-be-replaced-by-token-sub
+x-token-role: should-be-replaced-by-token-role
+x-token-aud: should-be-replaced-by-token-aud
 x-not-in-token-but-in-output-claims: should-be-stripped
 x-not-in-token-but-also-not-output-claim: should-be-passed-as-is
 Authorization: Bearer {{token}}

--- a/test/chainsaw/authpolicy/output_claims_to_headers/tests.hurl
+++ b/test/chainsaw/authpolicy/output_claims_to_headers/tests.hurl
@@ -6,6 +6,8 @@ HTTP 403
 # --- Expecting 200
 GET https://127.0.0.1:8443/random/path
 Host: foo.bar
+x-not-in-token-but-in-output-claims: should-be-stripped
+x-not-in-token-but-also-not-output-claim: should-be-passed-as-is
 Authorization: Bearer {{token}}
 HTTP 200
 Content-Type: application/json; charset=utf-8
@@ -13,3 +15,5 @@ Content-Type: application/json; charset=utf-8
 jsonpath "$.headers.x-token-sub" == "maskinporten_client"
 jsonpath "$.headers.x-token-role" == "maskinporten_role"
 jsonpath "$.headers.x-token-aud" == "WyJtYXNraW5wb3J0ZW5fc2VydmVyIiwibWFza2lucG9ydGVuX2NsaWVudCJd" # base64 encoded as aud-claim is of type array(string)
+jsonpath "$.headers.x-not-in-token-but-in-output-claims" not exists
+jsonpath "$.headers.x-not-in-token-but-also-not-output-claim" == "should-be-passed-as-is"


### PR DESCRIPTION
## Checklist
- [x] Commits follow best practice git conventions
- [x] Introduced dependencies are reviewed
- [x] Test coverage is adequate
- [x] New features are documented on `skip.kartverket.no`
- [x] Changes to CRD are documented on `skip.kartverket.no`
- [x] `setup-skip-action` and `test-authpolicy-action` are compatible with changes

## Description
We get some questions regarding what happens to headers, based on whether the header is listed in outputClaimToHeaders or not. Here, I expand the testing to cover the most common cases, including:

- headers that are present and not mentioned in outputClaimToHeader are passed as is

- headers that are present, are mentioned in outputClaimToHeader, and the token does not container the corresponding claim, are stripped