### PR TITLE
Add managed-by and controller labels

### DIFF
--- a/internal/controller/authpolicy_controller.go
+++ b/internal/controller/authpolicy_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	ztoperatorv1alpha1 "github.com/kartverket/ztoperator/api/v1alpha1"
 	"github.com/kartverket/ztoperator/internal/eventhandler/configmap"
@@ -14,6 +15,7 @@ import (
 	"github.com/kartverket/ztoperator/internal/state"
 	"github.com/kartverket/ztoperator/internal/statusmanager"
 	"github.com/kartverket/ztoperator/pkg/helperfunctions"
+	"github.com/kartverket/ztoperator/pkg/labels"
 	"github.com/kartverket/ztoperator/pkg/log"
 	"github.com/kartverket/ztoperator/pkg/metrics"
 	"github.com/kartverket/ztoperator/pkg/reconciliation"
@@ -104,6 +106,17 @@ func (r *AuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		rLog.Info(fmt.Sprintf("Deleting AuthPolicy with name %s", req.String()))
 		metrics.DeleteAuthPolicyInfo(req.NamespacedName)
 		return ctrl.Result{}, nil
+	}
+
+	if originalAuthPolicy.Labels == nil {
+		originalAuthPolicy.Labels = make(map[string]string)
+	}
+	maps.Copy(originalAuthPolicy.Labels, labels.AuthPolicyStandardLabels())
+	if !maps.Equal(originalAuthPolicy.Labels, authPolicy.Labels) {
+		err := r.Patch(ctx, originalAuthPolicy, client.MergeFrom(authPolicy))
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	scope, err := resolveAuthPolicy(ctx, r.Client, authPolicy, r.DiscoveryDocumentResolver)

--- a/internal/reconciler/actions.go
+++ b/internal/reconciler/actions.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kartverket/ztoperator/internal/names"
 	"github.com/kartverket/ztoperator/internal/state"
 	"github.com/kartverket/ztoperator/pkg/helperfunctions"
+	"github.com/kartverket/ztoperator/pkg/labels"
 	"github.com/kartverket/ztoperator/pkg/reconciliation"
 	"github.com/kartverket/ztoperator/pkg/resourcegenerators/authorizationpolicy/deny"
 	"github.com/kartverket/ztoperator/pkg/resourcegenerators/authorizationpolicy/ignore"
@@ -18,6 +19,7 @@ import (
 	v1alpha4 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istioclientsecurityv1 "istio.io/client-go/pkg/apis/security/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ReconcileActions creates all reconcile actions for the given AuthPolicy scope.
@@ -39,10 +41,7 @@ secretReconcileAction reconciles a Secret resource containing a HMAC secret (coo
 func secretReconcileAction(scope *state.Scope) AuthPolicyAdapter[*v1.Secret] {
 	desiredResource := secret.GetDesired(
 		scope,
-		helperfunctions.BuildObjectMeta(
-			scope.AutoLoginConfig.EnvoySecretName,
-			scope.AuthPolicy.Namespace,
-		),
+		buildObjectMeta(scope.AutoLoginConfig.EnvoySecretName, scope.AuthPolicy.Namespace),
 	)
 
 	return AuthPolicyAdapter[*v1.Secret]{
@@ -62,11 +61,13 @@ func secretReconcileAction(scope *state.Scope) AuthPolicyAdapter[*v1.Secret] {
 func secretShouldUpdate(current, desired *v1.Secret) bool {
 	desiredTokenSecret, hasDesired := desired.Data[configpatch.TokenSecretFileName]
 	currentTokenSecret, hasCurrent := current.Data[configpatch.TokenSecretFileName]
-	return !hasDesired || !hasCurrent || !bytes.Equal(currentTokenSecret, desiredTokenSecret)
+	return !hasDesired || !hasCurrent || !bytes.Equal(currentTokenSecret, desiredTokenSecret) ||
+		labelsNeedUpdate(current, desired)
 }
 
 func secretUpdateFields(current, desired *v1.Secret) {
 	current.Data = desired.Data
+	current.Labels = desired.Labels
 }
 
 /*
@@ -77,7 +78,7 @@ func envoyFilterReconcileAction(scope *state.Scope) AuthPolicyAdapter[*v1alpha4.
 	autoLoginEnvoyFilterName := names.EnvoyFilter(scope.AuthPolicy.Name)
 	desiredResource := envoyfilter.GetDesired(
 		scope,
-		helperfunctions.BuildObjectMeta(autoLoginEnvoyFilterName, scope.AuthPolicy.Namespace),
+		buildObjectMeta(autoLoginEnvoyFilterName, scope.AuthPolicy.Namespace),
 	)
 
 	return AuthPolicyAdapter[*v1alpha4.EnvoyFilter]{
@@ -101,12 +102,14 @@ func envoyFilterShouldUpdate(current, desired *v1alpha4.EnvoyFilter) bool {
 	) || !reflect.DeepEqual(
 		current.Spec.GetConfigPatches(),
 		desired.Spec.GetConfigPatches(),
-	)
+	) ||
+		labelsNeedUpdate(current, desired)
 }
 
 func envoyFilterUpdateFields(current, desired *v1alpha4.EnvoyFilter) {
 	current.Spec.WorkloadSelector = desired.Spec.GetWorkloadSelector()
 	current.Spec.ConfigPatches = desired.Spec.GetConfigPatches()
+	current.Labels = desired.Labels
 }
 
 /*
@@ -119,7 +122,7 @@ func requestAuthenticationReconcileAction(
 	requestAuthenticationName := scope.AuthPolicy.Name
 	desiredResource := requestauthentication.GetDesired(
 		scope,
-		helperfunctions.BuildObjectMeta(requestAuthenticationName, scope.AuthPolicy.Namespace),
+		buildObjectMeta(requestAuthenticationName, scope.AuthPolicy.Namespace),
 	)
 
 	return AuthPolicyAdapter[*istioclientsecurityv1.RequestAuthentication]{
@@ -138,12 +141,14 @@ func requestAuthenticationReconcileAction(
 
 func requestAuthenticationShouldUpdate(current, desired *istioclientsecurityv1.RequestAuthentication) bool {
 	return !reflect.DeepEqual(current.Spec.GetSelector(), desired.Spec.GetSelector()) ||
-		!reflect.DeepEqual(current.Spec.GetJwtRules(), desired.Spec.GetJwtRules())
+		!reflect.DeepEqual(current.Spec.GetJwtRules(), desired.Spec.GetJwtRules()) ||
+		labelsNeedUpdate(current, desired)
 }
 
 func requestAuthenticationUpdateFields(current, desired *istioclientsecurityv1.RequestAuthentication) {
 	current.Spec.Selector = desired.Spec.GetSelector()
 	current.Spec.JwtRules = desired.Spec.GetJwtRules()
+	current.Labels = desired.Labels
 }
 
 /*
@@ -157,7 +162,7 @@ func denyAuthorizationPolicyReconcileAction(
 	denyAuthorizationPolicyName := names.DenyPolicy(scope.AuthPolicy.Name)
 	desiredResource := deny.GetDesired(
 		scope,
-		helperfunctions.BuildObjectMeta(denyAuthorizationPolicyName, scope.AuthPolicy.Namespace),
+		buildObjectMeta(denyAuthorizationPolicyName, scope.AuthPolicy.Namespace),
 	)
 
 	return AuthPolicyAdapter[*istioclientsecurityv1.AuthorizationPolicy]{
@@ -185,7 +190,7 @@ func ignoreAuthorizationPolicyReconcileAction(
 	ignoreAuthAuthorizationPolicyName := names.IgnorePolicy(scope.AuthPolicy.Name)
 	desiredResource := ignore.GetDesired(
 		scope,
-		helperfunctions.BuildObjectMeta(ignoreAuthAuthorizationPolicyName, scope.AuthPolicy.Namespace),
+		buildObjectMeta(ignoreAuthAuthorizationPolicyName, scope.AuthPolicy.Namespace),
 	)
 
 	return AuthPolicyAdapter[*istioclientsecurityv1.AuthorizationPolicy]{
@@ -213,7 +218,7 @@ func requireAuthorizationPolicyReconcileAction(
 	requireAuthAuthorizationPolicyName := names.RequirePolicy(scope.AuthPolicy.Name)
 	desiredResource := require.GetDesired(
 		scope,
-		helperfunctions.BuildObjectMeta(requireAuthAuthorizationPolicyName, scope.AuthPolicy.Namespace),
+		buildObjectMeta(requireAuthAuthorizationPolicyName, scope.AuthPolicy.Namespace),
 	)
 
 	return AuthPolicyAdapter[*istioclientsecurityv1.AuthorizationPolicy]{
@@ -232,10 +237,37 @@ func requireAuthorizationPolicyReconcileAction(
 
 func authorizationPolicyShouldUpdate(current, desired *istioclientsecurityv1.AuthorizationPolicy) bool {
 	return !reflect.DeepEqual(current.Spec.GetSelector(), desired.Spec.GetSelector()) ||
-		!reflect.DeepEqual(current.Spec.GetRules(), desired.Spec.GetRules())
+		!reflect.DeepEqual(current.Spec.GetRules(), desired.Spec.GetRules()) ||
+		labelsNeedUpdate(current, desired)
 }
 
 func authorizationPolicyUpdateFields(current, desired *istioclientsecurityv1.AuthorizationPolicy) {
 	current.Spec.Selector = desired.Spec.GetSelector()
 	current.Spec.Rules = desired.Spec.GetRules()
+	current.Labels = desired.Labels
+}
+
+type LabeledObject interface {
+	GetLabels() map[string]string
+}
+
+// labelsNeedUpdate reports whether any of the desired labels are missing from current or have a
+// different value. Labels on current that are not part of the desired set are ignored.
+func labelsNeedUpdate(current, desired LabeledObject) bool {
+	desiredLabels := desired.GetLabels()
+	currentLabels := current.GetLabels()
+	for key, value := range desiredLabels {
+		if currentValue, ok := currentLabels[key]; !ok || currentValue != value {
+			return true
+		}
+	}
+	return false
+}
+
+func buildObjectMeta(name, namespace string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+		Labels:    labels.AuthPolicyStandardLabels(),
+	}
 }

--- a/pkg/helperfunctions/helper_functions.go
+++ b/pkg/helperfunctions/helper_functions.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/kartverket/ztoperator/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -37,14 +36,6 @@ func LowestNonZeroResult(i, j ctrl.Result) ctrl.Result {
 		return j
 	default:
 		return ctrl.Result{RequeueAfter: 0 * time.Second}
-	}
-}
-
-func BuildObjectMeta(name, namespace string) metav1.ObjectMeta {
-	return metav1.ObjectMeta{
-		Name:      name,
-		Namespace: namespace,
-		Labels:    map[string]string{"type": "ztoperator.kartverket.no"},
 	}
 }
 

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -1,0 +1,21 @@
+package labels
+
+const (
+	ManagedByLabelKey  = "app.kubernetes.io/managed-by"
+	ControllerLabelKey = "ztoperator.kartverket.no/controller"
+	TypeLabelKey       = "type"
+
+	ManagedByLabelValue            = "ztoperator"
+	AuthPolicyControllerLabelValue = "authpolicy"
+	TypeLabelValue                 = "ztoperator.kartverket.no"
+)
+
+// AuthPolicyStandardLabels returns the set of labels applied to every resource created by Ztoperator for the AuthPolicy
+// controller.
+func AuthPolicyStandardLabels() map[string]string {
+	return map[string]string{
+		ManagedByLabelKey:  ManagedByLabelValue,
+		ControllerLabelKey: AuthPolicyControllerLabelValue,
+		TypeLabelKey:       TypeLabelValue,
+	}
+}

--- a/test/chainsaw/authpolicy/audience_referencing/authpolicy-assert.yaml
+++ b/test/chainsaw/authpolicy/audience_referencing/authpolicy-assert.yaml
@@ -2,6 +2,9 @@ apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: auth-policy
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   jwtRules:
     - audiences:
@@ -19,6 +22,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: auth-policy-require-auth
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   rules:
     - to:

--- a/test/chainsaw/authpolicy/audience_referencing/authpolicy-with-allowed-audience-assert.yaml
+++ b/test/chainsaw/authpolicy/audience_referencing/authpolicy-with-allowed-audience-assert.yaml
@@ -2,6 +2,9 @@ apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: auth-policy
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   jwtRules:
     - audiences:
@@ -19,6 +22,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: auth-policy-require-auth
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   rules:
     - to:

--- a/test/chainsaw/authpolicy/audience_referencing/authpolicy-with-illegal-audience-valueref-assert.yaml
+++ b/test/chainsaw/authpolicy/audience_referencing/authpolicy-with-illegal-audience-valueref-assert.yaml
@@ -2,6 +2,9 @@ apiVersion: ztoperator.kartverket.no/v1alpha1
 kind: AuthPolicy
 metadata:
   name: auth-policy
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 status:
   phase: Failed
   ready: false

--- a/test/chainsaw/authpolicy/audience_update_triggers_reconcile/assert-after-configmap-update.yaml
+++ b/test/chainsaw/authpolicy/audience_update_triggers_reconcile/assert-after-configmap-update.yaml
@@ -2,6 +2,9 @@ apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: auth-policy
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   jwtRules:
     - audiences:

--- a/test/chainsaw/authpolicy/audience_update_triggers_reconcile/assert-after-secret-update.yaml
+++ b/test/chainsaw/authpolicy/audience_update_triggers_reconcile/assert-after-secret-update.yaml
@@ -2,6 +2,9 @@ apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: auth-policy
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   jwtRules:
     - audiences:

--- a/test/chainsaw/authpolicy/audience_update_triggers_reconcile/assert-initial.yaml
+++ b/test/chainsaw/authpolicy/audience_update_triggers_reconcile/assert-initial.yaml
@@ -2,6 +2,9 @@ apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: auth-policy
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   jwtRules:
     - audiences:
@@ -18,6 +21,9 @@ apiVersion: ztoperator.kartverket.no/v1alpha1
 kind: AuthPolicy
 metadata:
   name: auth-policy
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 status:
   phase: Ready
   ready: true

--- a/test/chainsaw/authpolicy/baseline_auth_resource_assertion/authpolicy-baseline-auth-and-auth-rules-assert.yaml
+++ b/test/chainsaw/authpolicy/baseline_auth_resource_assertion/authpolicy-baseline-auth-and-auth-rules-assert.yaml
@@ -4,6 +4,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: auth-policy-baseline-auth-and-auth-rules-deny-auth-rules
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   action: DENY
   rules:
@@ -48,6 +51,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: auth-policy-baseline-auth-and-auth-rules-require-auth
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   rules:
     - to:

--- a/test/chainsaw/authpolicy/baseline_auth_resource_assertion/authpolicy-baseline-auth-and-ignore-auth-rules-assert.yaml
+++ b/test/chainsaw/authpolicy/baseline_auth_resource_assertion/authpolicy-baseline-auth-and-ignore-auth-rules-assert.yaml
@@ -3,6 +3,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: auth-policy-baseline-auth-and-ignore-auth-rules-require-auth
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   rules:
     - to:

--- a/test/chainsaw/authpolicy/baseline_auth_resource_assertion/authpolicy-only-baseline-auth-assert.yaml
+++ b/test/chainsaw/authpolicy/baseline_auth_resource_assertion/authpolicy-only-baseline-auth-assert.yaml
@@ -3,6 +3,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: auth-policy-only-baseline-auth-require-auth
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   rules:
     - to:

--- a/test/chainsaw/authpolicy/baseline_auth_resource_assertion/authpolicy-with-all-rules-assert.yaml
+++ b/test/chainsaw/authpolicy/baseline_auth_resource_assertion/authpolicy-with-all-rules-assert.yaml
@@ -3,6 +3,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: auth-policy-with-all-rules-ignore-auth
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   rules:
     - to:
@@ -20,6 +23,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: auth-policy-with-all-rules-require-auth
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   rules:
     - to:

--- a/test/chainsaw/authpolicy/envoy-secret/authpolicy-assert.yaml
+++ b/test/chainsaw/authpolicy/envoy-secret/authpolicy-assert.yaml
@@ -4,4 +4,7 @@ data:
 kind: Secret
 metadata:
   name: auth-policy-envoy-secret
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 type: Opaque

--- a/test/chainsaw/authpolicy/path_validation/authpolicy-mixing-path-syntax-assert.yaml
+++ b/test/chainsaw/authpolicy/path_validation/authpolicy-mixing-path-syntax-assert.yaml
@@ -4,6 +4,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: mixing-old-and-new-path-syntax-deny-auth-rules
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   action: DENY
   rules:

--- a/test/chainsaw/authpolicy/path_validation/authpolicy-new-path-syntax-invalid-assert.yaml
+++ b/test/chainsaw/authpolicy/path_validation/authpolicy-new-path-syntax-invalid-assert.yaml
@@ -4,6 +4,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: single-asterix-not-alone-in-segment-deny-auth-rules
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   action: DENY
   rules:
@@ -21,6 +24,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: wildcard-after-double-asterix-deny-auth-rules
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   action: DENY
   rules:

--- a/test/chainsaw/authpolicy/path_validation/authpolicy-new-path-syntax-valid-assert.yaml
+++ b/test/chainsaw/authpolicy/path_validation/authpolicy-new-path-syntax-valid-assert.yaml
@@ -3,6 +3,9 @@ apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: auth-policy-valid-new-syntax
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   jwtRules:
     - audiences:
@@ -19,6 +22,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: auth-policy-valid-new-syntax-ignore-auth
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   rules:
     - to:
@@ -48,6 +54,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: auth-policy-valid-new-syntax-require-auth
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   rules:
     - to:

--- a/test/chainsaw/authpolicy/path_validation/authpolicy-old-path-syntax-invalid-assert.yaml
+++ b/test/chainsaw/authpolicy/path_validation/authpolicy-old-path-syntax-invalid-assert.yaml
@@ -4,6 +4,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: asterix-in-path-deny-auth-rules
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   action: DENY
   rules:
@@ -20,6 +23,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: only-asterix-deny-auth-rules
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   action: DENY
   rules:
@@ -36,6 +42,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: leading-asterix-deny-auth-rules
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   action: DENY
   rules:

--- a/test/chainsaw/authpolicy/path_validation/authpolicy-old-path-syntax-valid-assert.yaml
+++ b/test/chainsaw/authpolicy/path_validation/authpolicy-old-path-syntax-valid-assert.yaml
@@ -3,6 +3,9 @@ apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: auth-policy-valid-old-syntax
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   jwtRules:
     - audiences:
@@ -19,6 +22,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: auth-policy-valid-old-syntax-ignore-auth
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   rules:
     - to:
@@ -36,6 +42,9 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: auth-policy-valid-old-syntax-require-auth
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
 spec:
   rules:
     - to:


### PR DESCRIPTION
## Checklist
- [x] Commits follow best practice git conventions
- [x] Introduced dependencies are reviewed
- [ ] (only tested through chainsaw for now) Test coverage is adequate
- [x] New features are documented on `skip.kartverket.no`
- [x] Changes to CRD are documented on `skip.kartverket.no`
- [x] `setup-skip-action` and `test-authpolicy-action` are compatible with changes

## Description
These are, among other, recommended labels by Kubernetes. For operators, the former usually refers to the operator name. The latter is the controller, which is useful in the case where the same operator handles multiple CRDs (we don't currently, but maybe in the future).

Other recommended labels are name, instance, component, part-of etc, but we only really have use for the managed-by annotation for now. This will be used to fetch owned resources during reconciliation, which we may decide to implement should we find a suitable solution.

All reconciliation testing is done through chainsaw tests for now. There is a separate task related to adding unit/ginkgo test coverage for remaining packages.