### PR TITLE
Rename files and types related to reconciliation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Controller.Reconcile()
   ├─ validateAuthPolicy()        ← Validators (pkg/validation/)
   │   ├─ Path validation           (RFC 3986 pchar, template syntax {*}, {**})
   │   └─ Pod annotation validation (sidecar.istio.io/userVolume + userVolumeMount must reference the envoy secret)
-  ├─ ReconcileActions()           ← Builds list of 6 reconcile actions (internal/reconciler/actions.go)
+  ├─ ControllerResources()        ← Builds list of 6 controller resources (internal/reconciler/resources.go)
   │   ├─ Secret
   │   ├─ EnvoyFilter
   │   ├─ RequestAuthentication
@@ -64,7 +64,7 @@ Controller.Reconcile()
 | `api/v1alpha1/` | CRD type definitions with kubebuilder markers; `AuthPolicy`, `AuthPolicySpec`, status, conditions |
 | `cmd/main.go` | Entrypoint; scheme registration (Istio + K8s + ztoperator), manager setup |
 | `internal/controller/` | Reconciler loop; resolves, validates, reconciles, updates status |
-| `internal/reconciler/` | Generic adapter pattern for reconciling any `client.Object`. `actions.go` defines the 6 reconcile actions |
+| `internal/reconciler/` | Generic adapter pattern for reconciling any `client.Object`. `resources.go` defines the 6 reconcile resources |
 | `internal/names/` | Centralised child resource name generation functions (e.g. `EnvoyFilter`, `DenyPolicy`) |
 | `internal/resolver/` | Resolvers: audience, OAuth credentials, discovery document, auto-login config |
 | `internal/state/` | `Scope` struct — the resolved state bag passed through reconciliation (AuthPolicy + resolved values + descendants) |
@@ -81,7 +81,7 @@ Controller.Reconcile()
 | `pkg/resourcegenerators/secret/` | Envoy Secret generation (HMAC + token secret) |
 | `pkg/luascript/` | Lua script templating (`ztoperator.lua` embedded via `//go:embed`); handles login/logout/redirect/deny-redirect logic |
 | `pkg/validation/` | Path validation (RFC 3986, template patterns `{*}` / `{**}`), pod annotation validation; `path_classifier.go` distinguishes exact/prefix/template paths, `path_transformation.go` normalises them before matching |
-| `pkg/reconciliation/` | `ReconcileAction` interface and generic `ReconcileFunc` / `ReconcileFuncAdapter` types |
+| `pkg/reconciliation/` | `ControllerResource` interface and generic `ReconcilerAdapter[T]` / `ResourceReconciler[T]` types |
 | `pkg/metrics/` | Prometheus gauge `ztoperator_authpolicy_info` with labels: name, namespace, state, owner, issuer, enabled, auto_login_enabled, protected_pod |
 | `pkg/rest/` | OIDC discovery document HTTP client (uses resty); `DiscoveryDocumentResolver` interface in `client.go` is the main test seam injected into the controller; pre-seeded static map of known providers in `dto.go` |
 | `pkg/config/` | Env-based config via `envconfig` (currently just `ZTOPERATOR_GIT_REF`) |
@@ -93,10 +93,10 @@ Controller.Reconcile()
 The reconciler uses a **generic adapter pattern** with Go generics:
 
 ```go
-AuthPolicyAdapter[T client.Object]  →  ReconcileFuncAdapter[T]  →  ReconcileFunc[T]
+ReconcilerAdapter[T client.Object]  →  ResourceReconciler[T]
 ```
 
-Each `ReconcileFunc[T]` specifies:
+Each `ResourceReconciler[T]` specifies:
 - `DesiredResource`: the desired state (or nil to trigger deletion)
 - `ShouldUpdate(current, desired T) bool`: comparison function
 - `UpdateFields(current, desired T)`: field-level update function

--- a/internal/controller/authpolicy_controller.go
+++ b/internal/controller/authpolicy_controller.go
@@ -133,18 +133,18 @@ func (r *AuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	scope = validateAuthPolicy(ctx, scope)
 
-	reconcileActions := reconciler.ReconcileActions(scope)
+	controllerResources := reconciler.ControllerResources(scope)
 
 	defer func() {
-		statusmanager.UpdateAuthPolicyStatus(ctx, r.Client, r.Recorder, scope, originalAuthPolicy, reconcileActions)
+		statusmanager.UpdateAuthPolicyStatus(ctx, r.Client, r.Recorder, scope, originalAuthPolicy, controllerResources)
 	}()
 
-	return r.doReconcile(ctx, reconcileActions, scope)
+	return r.doReconcile(ctx, controllerResources, scope)
 }
 
 func (r *AuthPolicyReconciler) doReconcile(
 	ctx context.Context,
-	reconcileFuncs []reconciliation.ReconcileAction,
+	reconcileFuncs []reconciliation.ControllerResource,
 	scope *state.Scope,
 ) (ctrl.Result, error) {
 	result := ctrl.Result{}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -14,12 +14,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// AuthPolicyAdapter implements the ReconcileAction interface.
-type AuthPolicyAdapter[T client.Object] struct {
-	reconciliation.ReconcileFuncAdapter[T]
+// ControllerResourceAdapter implements the ControllerResource interface.
+type ControllerResourceAdapter[T client.Object] struct {
+	reconciliation.ReconcilerAdapter[T]
 }
 
-func (a AuthPolicyAdapter[T]) Reconcile(
+func (a ControllerResourceAdapter[T]) Reconcile(
 	ctx context.Context,
 	k8sClient client.Client,
 	scheme *runtime.Scheme,
@@ -37,15 +37,15 @@ func (a AuthPolicyAdapter[T]) Reconcile(
 	)
 }
 
-func (a AuthPolicyAdapter[T]) GetResourceKind() string {
+func (a ControllerResourceAdapter[T]) GetResourceKind() string {
 	return a.Func.ResourceKind
 }
 
-func (a AuthPolicyAdapter[T]) GetResourceName() string {
+func (a ControllerResourceAdapter[T]) GetResourceName() string {
 	return a.Func.ResourceName
 }
 
-func (a AuthPolicyAdapter[T]) IsResourceNil() bool {
+func (a ControllerResourceAdapter[T]) IsResourceNil() bool {
 	return a.Func.DesiredResource == nil || reflect.ValueOf(*a.Func.DesiredResource).IsNil()
 }
 

--- a/internal/reconciler/resources.go
+++ b/internal/reconciler/resources.go
@@ -22,31 +22,31 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ReconcileActions creates all reconcile actions for the given AuthPolicy scope.
-func ReconcileActions(scope *state.Scope) []reconciliation.ReconcileAction {
-	return []reconciliation.ReconcileAction{
-		secretReconcileAction(scope),
-		envoyFilterReconcileAction(scope),
-		requestAuthenticationReconcileAction(scope),
-		denyAuthorizationPolicyReconcileAction(scope),
-		ignoreAuthorizationPolicyReconcileAction(scope),
-		requireAuthorizationPolicyReconcileAction(scope),
+// ControllerResources creates all reconcile actions for the given AuthPolicy scope.
+func ControllerResources(scope *state.Scope) []reconciliation.ControllerResource {
+	return []reconciliation.ControllerResource{
+		secretResource(scope),
+		envoyFilterResource(scope),
+		requestAuthenticationResource(scope),
+		denyAuthorizationPolicyResource(scope),
+		ignoreAuthorizationPolicyResource(scope),
+		requireAuthorizationPolicyResource(scope),
 	}
 }
 
 /*
-secretReconcileAction reconciles a Secret resource containing a HMAC secret (cookie signing key) and token secret
+secretResource reconciles a Secret resource containing a HMAC secret (cookie signing key) and token secret
 (OAuth client secret), if auto-login is enabled. The secrets are used by Envoy during Authorization Code Flow.
 */
-func secretReconcileAction(scope *state.Scope) AuthPolicyAdapter[*v1.Secret] {
+func secretResource(scope *state.Scope) ControllerResourceAdapter[*v1.Secret] {
 	desiredResource := secret.GetDesired(
 		scope,
 		buildObjectMeta(scope.AutoLoginConfig.EnvoySecretName, scope.AuthPolicy.Namespace),
 	)
 
-	return AuthPolicyAdapter[*v1.Secret]{
-		reconciliation.ReconcileFuncAdapter[*v1.Secret]{
-			Func: reconciliation.ReconcileFunc[*v1.Secret]{
+	return ControllerResourceAdapter[*v1.Secret]{
+		reconciliation.ReconcilerAdapter[*v1.Secret]{
+			Func: reconciliation.ResourceReconciler[*v1.Secret]{
 				ResourceKind:    "Secret",
 				ResourceName:    scope.AutoLoginConfig.EnvoySecretName,
 				DesiredResource: helperfunctions.Ptr(desiredResource),
@@ -71,19 +71,19 @@ func secretUpdateFields(current, desired *v1.Secret) {
 }
 
 /*
-envoyFilterReconcileAction reconciles an EnvoyFilter resource based on the configured AuthPolicy, enforcing auto-login
+envoyFilterResource reconciles an EnvoyFilter resource based on the configured AuthPolicy, enforcing auto-login
 behavior for unauthenticated requests when enabled. The EnvoyFilter handles OAuth2 Authorization Code Flow.
 */
-func envoyFilterReconcileAction(scope *state.Scope) AuthPolicyAdapter[*v1alpha4.EnvoyFilter] {
+func envoyFilterResource(scope *state.Scope) ControllerResourceAdapter[*v1alpha4.EnvoyFilter] {
 	autoLoginEnvoyFilterName := names.EnvoyFilter(scope.AuthPolicy.Name)
 	desiredResource := envoyfilter.GetDesired(
 		scope,
 		buildObjectMeta(autoLoginEnvoyFilterName, scope.AuthPolicy.Namespace),
 	)
 
-	return AuthPolicyAdapter[*v1alpha4.EnvoyFilter]{
-		reconciliation.ReconcileFuncAdapter[*v1alpha4.EnvoyFilter]{
-			Func: reconciliation.ReconcileFunc[*v1alpha4.EnvoyFilter]{
+	return ControllerResourceAdapter[*v1alpha4.EnvoyFilter]{
+		reconciliation.ReconcilerAdapter[*v1alpha4.EnvoyFilter]{
+			Func: reconciliation.ResourceReconciler[*v1alpha4.EnvoyFilter]{
 				ResourceKind:    "EnvoyFilter",
 				ResourceName:    autoLoginEnvoyFilterName,
 				DesiredResource: helperfunctions.Ptr(desiredResource),
@@ -113,21 +113,21 @@ func envoyFilterUpdateFields(current, desired *v1alpha4.EnvoyFilter) {
 }
 
 /*
-requestAuthenticationReconcileAction reconciles a RequestAuthentication resource based on the configured AuthPolicy,
+requestAuthenticationResource reconciles a RequestAuthentication resource based on the configured AuthPolicy,
 defining the JWT authentication requirements and how to forward the original token and output claims to http headers.
 */
-func requestAuthenticationReconcileAction(
+func requestAuthenticationResource(
 	scope *state.Scope,
-) AuthPolicyAdapter[*istioclientsecurityv1.RequestAuthentication] {
+) ControllerResourceAdapter[*istioclientsecurityv1.RequestAuthentication] {
 	requestAuthenticationName := scope.AuthPolicy.Name
 	desiredResource := requestauthentication.GetDesired(
 		scope,
 		buildObjectMeta(requestAuthenticationName, scope.AuthPolicy.Namespace),
 	)
 
-	return AuthPolicyAdapter[*istioclientsecurityv1.RequestAuthentication]{
-		reconciliation.ReconcileFuncAdapter[*istioclientsecurityv1.RequestAuthentication]{
-			Func: reconciliation.ReconcileFunc[*istioclientsecurityv1.RequestAuthentication]{
+	return ControllerResourceAdapter[*istioclientsecurityv1.RequestAuthentication]{
+		reconciliation.ReconcilerAdapter[*istioclientsecurityv1.RequestAuthentication]{
+			Func: reconciliation.ResourceReconciler[*istioclientsecurityv1.RequestAuthentication]{
 				ResourceKind:    "RequestAuthentication",
 				ResourceName:    requestAuthenticationName,
 				DesiredResource: helperfunctions.Ptr(desiredResource),
@@ -152,22 +152,22 @@ func requestAuthenticationUpdateFields(current, desired *istioclientsecurityv1.R
 }
 
 /*
-denyAuthorizationPolicyReconcileAction reconciles DENY AuthorizationPolicy resources based on the configured AuthRules
+denyAuthorizationPolicyResource reconciles DENY AuthorizationPolicy resources based on the configured AuthRules
 and BaselineAuth, denying requests that do not satisfy the configured authentication requirements. DENY policies take
 precedence over ALLOW policies.
 */
-func denyAuthorizationPolicyReconcileAction(
+func denyAuthorizationPolicyResource(
 	scope *state.Scope,
-) AuthPolicyAdapter[*istioclientsecurityv1.AuthorizationPolicy] {
+) ControllerResourceAdapter[*istioclientsecurityv1.AuthorizationPolicy] {
 	denyAuthorizationPolicyName := names.DenyPolicy(scope.AuthPolicy.Name)
 	desiredResource := deny.GetDesired(
 		scope,
 		buildObjectMeta(denyAuthorizationPolicyName, scope.AuthPolicy.Namespace),
 	)
 
-	return AuthPolicyAdapter[*istioclientsecurityv1.AuthorizationPolicy]{
-		reconciliation.ReconcileFuncAdapter[*istioclientsecurityv1.AuthorizationPolicy]{
-			Func: reconciliation.ReconcileFunc[*istioclientsecurityv1.AuthorizationPolicy]{
+	return ControllerResourceAdapter[*istioclientsecurityv1.AuthorizationPolicy]{
+		reconciliation.ReconcilerAdapter[*istioclientsecurityv1.AuthorizationPolicy]{
+			Func: reconciliation.ResourceReconciler[*istioclientsecurityv1.AuthorizationPolicy]{
 				ResourceKind:    "AuthorizationPolicy",
 				ResourceName:    denyAuthorizationPolicyName,
 				DesiredResource: helperfunctions.Ptr(desiredResource),
@@ -180,22 +180,22 @@ func denyAuthorizationPolicyReconcileAction(
 }
 
 /*
-ignoreAuthorizationPolicyReconcileAction reconciles ALLOW AuthorizationPolicy resources based on the configured
+ignoreAuthorizationPolicyResource reconciles ALLOW AuthorizationPolicy resources based on the configured
 IgnoreAuthRules, allowing requests that satisfy the configured authentication requirements unless denied by any DENY
 policy.
 */
-func ignoreAuthorizationPolicyReconcileAction(
+func ignoreAuthorizationPolicyResource(
 	scope *state.Scope,
-) AuthPolicyAdapter[*istioclientsecurityv1.AuthorizationPolicy] {
+) ControllerResourceAdapter[*istioclientsecurityv1.AuthorizationPolicy] {
 	ignoreAuthAuthorizationPolicyName := names.IgnorePolicy(scope.AuthPolicy.Name)
 	desiredResource := ignore.GetDesired(
 		scope,
 		buildObjectMeta(ignoreAuthAuthorizationPolicyName, scope.AuthPolicy.Namespace),
 	)
 
-	return AuthPolicyAdapter[*istioclientsecurityv1.AuthorizationPolicy]{
-		reconciliation.ReconcileFuncAdapter[*istioclientsecurityv1.AuthorizationPolicy]{
-			Func: reconciliation.ReconcileFunc[*istioclientsecurityv1.AuthorizationPolicy]{
+	return ControllerResourceAdapter[*istioclientsecurityv1.AuthorizationPolicy]{
+		reconciliation.ReconcilerAdapter[*istioclientsecurityv1.AuthorizationPolicy]{
+			Func: reconciliation.ResourceReconciler[*istioclientsecurityv1.AuthorizationPolicy]{
 				ResourceKind:    "AuthorizationPolicy",
 				ResourceName:    ignoreAuthAuthorizationPolicyName,
 				DesiredResource: helperfunctions.Ptr(desiredResource),
@@ -208,22 +208,22 @@ func ignoreAuthorizationPolicyReconcileAction(
 }
 
 /*
-requireAuthorizationPolicyReconcileAction reconciles ALLOW AuthorizationPolicy resources based on the configured
+requireAuthorizationPolicyResource reconciles ALLOW AuthorizationPolicy resources based on the configured
 AuthRules, BaselineAuth and IgnoreAuthRules, allowing requests that satisfy the configured authentication requirements
 unless denied by any DENY policy.
 */
-func requireAuthorizationPolicyReconcileAction(
+func requireAuthorizationPolicyResource(
 	scope *state.Scope,
-) AuthPolicyAdapter[*istioclientsecurityv1.AuthorizationPolicy] {
+) ControllerResourceAdapter[*istioclientsecurityv1.AuthorizationPolicy] {
 	requireAuthAuthorizationPolicyName := names.RequirePolicy(scope.AuthPolicy.Name)
 	desiredResource := require.GetDesired(
 		scope,
 		buildObjectMeta(requireAuthAuthorizationPolicyName, scope.AuthPolicy.Namespace),
 	)
 
-	return AuthPolicyAdapter[*istioclientsecurityv1.AuthorizationPolicy]{
-		reconciliation.ReconcileFuncAdapter[*istioclientsecurityv1.AuthorizationPolicy]{
-			Func: reconciliation.ReconcileFunc[*istioclientsecurityv1.AuthorizationPolicy]{
+	return ControllerResourceAdapter[*istioclientsecurityv1.AuthorizationPolicy]{
+		reconciliation.ReconcilerAdapter[*istioclientsecurityv1.AuthorizationPolicy]{
+			Func: reconciliation.ResourceReconciler[*istioclientsecurityv1.AuthorizationPolicy]{
 				ResourceKind:    "AuthorizationPolicy",
 				ResourceName:    requireAuthAuthorizationPolicyName,
 				DesiredResource: helperfunctions.Ptr(desiredResource),

--- a/internal/statusmanager/condition_builder.go
+++ b/internal/statusmanager/condition_builder.go
@@ -18,7 +18,7 @@ func BuildConditions(
 	reconciliationState ReconciliationState,
 	validationErrorMessage *string,
 	descendants []state.Descendant[client.Object],
-	reconcileFuncs []reconciliation.ReconcileAction,
+	reconcileFuncs []reconciliation.ControllerResource,
 	existingConditions []metav1.Condition,
 ) []metav1.Condition {
 	authPolicyCondition := BuildAuthPolicyCondition(
@@ -125,7 +125,7 @@ func BuildDescendantConditions(
 // BuildMissingResourceConditions builds conditions for resources that were expected but not found.
 func BuildMissingResourceConditions(
 	descendants []state.Descendant[client.Object],
-	reconcileFuncs []reconciliation.ReconcileAction,
+	reconcileFuncs []reconciliation.ControllerResource,
 	existingConditions []metav1.Condition,
 ) []metav1.Condition {
 	var conditions []metav1.Condition

--- a/internal/statusmanager/condition_builder_test.go
+++ b/internal/statusmanager/condition_builder_test.go
@@ -371,7 +371,7 @@ func TestBuildMissingResourceConditions_WithNoMissingResources_ReturnsEmptySlice
 	descendants := []state.Descendant[client.Object]{
 		{ID: "Secret-my-secret", Object: &v1.Secret{}},
 	}
-	reconcileFuncs := []reconciliation.ReconcileAction{
+	reconcileFuncs := []reconciliation.ControllerResource{
 		createMockReconcileAction("Secret", "my-secret", false),
 	}
 
@@ -385,7 +385,7 @@ func TestBuildMissingResourceConditions_WithNoMissingResources_ReturnsEmptySlice
 func TestBuildMissingResourceConditions_WithMissingResource_ReturnsFalseCondition(t *testing.T) {
 	// 1. Arrange
 	descendants := []state.Descendant[client.Object]{}
-	reconcileFuncs := []reconciliation.ReconcileAction{
+	reconcileFuncs := []reconciliation.ControllerResource{
 		createMockReconcileAction("Secret", "expected-secret", false),
 	}
 
@@ -403,7 +403,7 @@ func TestBuildMissingResourceConditions_WithMissingResource_ReturnsFalseConditio
 func TestBuildMissingResourceConditions_WithNilResource_IgnoresIt(t *testing.T) {
 	// 1. Arrange
 	descendants := []state.Descendant[client.Object]{}
-	reconcileFuncs := []reconciliation.ReconcileAction{
+	reconcileFuncs := []reconciliation.ControllerResource{
 		createMockReconcileAction("Secret", "some-secret", true),
 	}
 
@@ -419,7 +419,7 @@ func TestBuildMissingResourceConditions_WithPartiallyMissingResources_ReturnsOnl
 	descendants := []state.Descendant[client.Object]{
 		{ID: "Secret-present-secret", Object: &v1.Secret{}},
 	}
-	reconcileFuncs := []reconciliation.ReconcileAction{
+	reconcileFuncs := []reconciliation.ControllerResource{
 		createMockReconcileAction("Secret", "present-secret", false),
 		createMockReconcileAction("ConfigMap", "missing-config", false),
 		createMockReconcileAction("Secret", "missing-secret", false),
@@ -437,7 +437,7 @@ func TestBuildMissingResourceConditions_WithPartiallyMissingResources_ReturnsOnl
 func TestBuildMissingResourceConditions_WithNoExistingConditions_SetsNewLastTransitionTime(t *testing.T) {
 	// 1. Arrange
 	var descendants []state.Descendant[client.Object]
-	reconcileFuncs := []reconciliation.ReconcileAction{
+	reconcileFuncs := []reconciliation.ControllerResource{
 		createMockReconcileAction("Secret", "expected-secret", false),
 	}
 
@@ -453,7 +453,7 @@ func TestBuildMissingResourceConditions_WithNoExistingConditions_SetsNewLastTran
 func TestBuildMissingResourceConditions_WithIdenticalExistingCondition_PreservesLastTransitionTime(t *testing.T) {
 	// 1. Arrange
 	var descendants []state.Descendant[client.Object]
-	reconcileFuncs := []reconciliation.ReconcileAction{
+	reconcileFuncs := []reconciliation.ControllerResource{
 		createMockReconcileAction("Secret", "expected-secret", false),
 	}
 
@@ -483,7 +483,7 @@ func TestBuildMissingResourceConditions_WithIdenticalExistingCondition_Preserves
 func TestBuildMissingResourceConditions_WithDifferentExistingCondition_UpdatesLastTransitionTime(t *testing.T) {
 	// 1. Arrange
 	var descendants []state.Descendant[client.Object]
-	reconcileFuncs := []reconciliation.ReconcileAction{
+	reconcileFuncs := []reconciliation.ControllerResource{
 		createMockReconcileAction("Secret", "expected-secret", false),
 	}
 
@@ -525,7 +525,7 @@ func TestBuildConditions_IncludesAllConditionTypes(t *testing.T) {
 		},
 	}
 
-	reconcileFuncs := []reconciliation.ReconcileAction{
+	reconcileFuncs := []reconciliation.ControllerResource{
 		createMockReconcileAction("Secret", "oauth-secret", false),
 		createMockReconcileAction("RequestAuthentication", "my-auth", false),
 	}

--- a/internal/statusmanager/status_manager.go
+++ b/internal/statusmanager/status_manager.go
@@ -30,7 +30,7 @@ func UpdateAuthPolicyStatus(
 	recorder events.EventRecorder,
 	scope *state.Scope,
 	originalAuthPolicy *ztoperatorv1alpha1.AuthPolicy,
-	reconcileActions []reconciliation.ReconcileAction,
+	controllerResources []reconciliation.ControllerResource,
 ) {
 	ap := &scope.AuthPolicy
 	rLog := log.GetLogger(ctx)
@@ -43,7 +43,7 @@ func UpdateAuthPolicyStatus(
 		"Reconcile",
 		"Status update of AuthPolicy started.")
 
-	reconciliationState := DetermineReconciliationState(scope, reconcileActions)
+	reconciliationState := DetermineReconciliationState(scope, controllerResources)
 
 	ap.Status.ObservedGeneration = ap.GetGeneration()
 	ap.Status.Phase = determinePhase(reconciliationState)
@@ -54,7 +54,7 @@ func UpdateAuthPolicyStatus(
 		reconciliationState,
 		scope.ValidationErrorMessage,
 		scope.Descendants,
-		reconcileActions,
+		controllerResources,
 		originalAuthPolicy.Status.Conditions,
 	)
 
@@ -74,12 +74,12 @@ func UpdateAuthPolicyStatus(
 
 func DetermineReconciliationState(
 	scope *state.Scope,
-	reconcileActions []reconciliation.ReconcileAction,
+	controllerResources []reconciliation.ControllerResource,
 ) ReconciliationState {
 	switch {
 	case scope.InvalidConfig:
 		return StateInvalid
-	case len(scope.Descendants) != reconciliation.CountReconciledResources(reconcileActions):
+	case len(scope.Descendants) != reconciliation.CountNonNilResources(controllerResources):
 		return StatePending
 	case len(scope.GetErrors()) > 0:
 		return StateFailed

--- a/internal/statusmanager/status_manager_test.go
+++ b/internal/statusmanager/status_manager_test.go
@@ -26,10 +26,10 @@ func TestDetermineReconciliationState_WithInvalidConfig_ReturnsStateInvalid(t *t
 		ValidationErrorMessage: helperfunctions.Ptr("Invalid configuration"),
 		Descendants:            []state.Descendant[client.Object]{},
 	}
-	var reconcileActions []reconciliation.ReconcileAction
+	var controllerResources []reconciliation.ControllerResource
 
 	// 2. Act
-	result := statusmanager.DetermineReconciliationState(scope, reconcileActions)
+	result := statusmanager.DetermineReconciliationState(scope, controllerResources)
 
 	// 3. Assert
 	assert.Equal(t, statusmanager.StateInvalid, result)
@@ -43,13 +43,13 @@ func TestDetermineReconciliationState_WithMissingDescendants_ReturnsStatePending
 			{ID: "Secret-oauth-secret", Object: &v1.Secret{}},
 		},
 	}
-	reconcileActions := []reconciliation.ReconcileAction{
+	controllerResources := []reconciliation.ControllerResource{
 		createMockReconcileAction("Secret", "oauth-secret", false),           // Exists
 		createMockReconcileAction("RequestAuthentication", "my-auth", false), // Missing
 	}
 
 	// 2. Act
-	result := statusmanager.DetermineReconciliationState(scope, reconcileActions)
+	result := statusmanager.DetermineReconciliationState(scope, controllerResources)
 
 	// 3. Assert
 	assert.Equal(t, statusmanager.StatePending, result)
@@ -68,12 +68,12 @@ func TestDetermineReconciliationState_WithErrors_ReturnsStateFailed(t *testing.T
 			},
 		},
 	}
-	reconcileActions := []reconciliation.ReconcileAction{
+	controllerResources := []reconciliation.ControllerResource{
 		createMockReconcileAction("Secret", "oauth-secret", false),
 	}
 
 	// 2. Act
-	result := statusmanager.DetermineReconciliationState(scope, reconcileActions)
+	result := statusmanager.DetermineReconciliationState(scope, controllerResources)
 
 	// 3. Assert
 	assert.Equal(t, statusmanager.StateFailed, result)
@@ -92,12 +92,12 @@ func TestDetermineReconciliationState_WithValidConfigAndDescendantsAndNoErrors_R
 			},
 		},
 	}
-	reconcileActions := []reconciliation.ReconcileAction{
+	controllerResources := []reconciliation.ControllerResource{
 		createMockReconcileAction("Secret", "oauth-secret", false),
 	}
 
 	// 2. Act
-	result := statusmanager.DetermineReconciliationState(scope, reconcileActions)
+	result := statusmanager.DetermineReconciliationState(scope, controllerResources)
 
 	// 3. Assert
 	assert.Equal(t, statusmanager.StateReady, result)
@@ -119,13 +119,13 @@ func TestDetermineReconciliationState_InvalidConfigTakesPrecedenceOverPendingAnd
 			},
 		},
 	}
-	reconcileActions := []reconciliation.ReconcileAction{
+	controllerResources := []reconciliation.ControllerResource{
 		createMockReconcileAction("Secret", "oauth-secret", false),
 		createMockReconcileAction("RequestAuthentication", "my-auth", false),
 	}
 
 	// 2. Act
-	result := statusmanager.DetermineReconciliationState(scope, reconcileActions)
+	result := statusmanager.DetermineReconciliationState(scope, controllerResources)
 
 	// 3. Assert
 	assert.Equal(t, statusmanager.StateInvalid, result, "Invalid config should take precedence over other states")
@@ -144,13 +144,13 @@ func TestDetermineReconciliationState_PendingTakesPrecedenceOverFailed(t *testin
 			},
 		},
 	}
-	reconcileActions := []reconciliation.ReconcileAction{
+	controllerResources := []reconciliation.ControllerResource{
 		createMockReconcileAction("Secret", "oauth-secret", false),           // Exists
 		createMockReconcileAction("RequestAuthentication", "my-auth", false), // Missing
 	}
 
 	// 2. Act
-	result := statusmanager.DetermineReconciliationState(scope, reconcileActions)
+	result := statusmanager.DetermineReconciliationState(scope, controllerResources)
 
 	// 3. Assert
 	assert.Equal(t, statusmanager.StatePending, result, "Pending state should take precedence over failed state")
@@ -189,10 +189,10 @@ func TestUpdateAuthPolicyStatus_WithNoStatusChange_DoesNotUpdate(t *testing.T) {
 		InvalidConfig: false,
 		Descendants:   []state.Descendant[client.Object]{},
 	}
-	reconcileActions := []reconciliation.ReconcileAction{}
+	controllerResources := []reconciliation.ControllerResource{}
 
 	// 2. Act
-	statusmanager.UpdateAuthPolicyStatus(ctx, k8sClient, fakeRecorder, scope, originalAuthPolicy, reconcileActions)
+	statusmanager.UpdateAuthPolicyStatus(ctx, k8sClient, fakeRecorder, scope, originalAuthPolicy, controllerResources)
 
 	// 3. Assert
 	// Verify no status update recordedEvents were recorded (only StatusUpdateStarted)
@@ -239,12 +239,12 @@ func TestUpdateAuthPolicyStatus_WithSuccessfulStatusChange_RecordsNormalEvent(t 
 			},
 		},
 	}
-	reconcileActions := []reconciliation.ReconcileAction{
+	controllerResources := []reconciliation.ControllerResource{
 		createMockReconcileAction("Secret", "test", false),
 	}
 
 	// 2. Act
-	statusmanager.UpdateAuthPolicyStatus(ctx, k8sClient, fakeRecorder, scope, originalAuthPolicy, reconcileActions)
+	statusmanager.UpdateAuthPolicyStatus(ctx, k8sClient, fakeRecorder, scope, originalAuthPolicy, controllerResources)
 
 	// 3. Assert
 	close(fakeRecorder.Events)
@@ -287,10 +287,10 @@ func TestUpdateAuthPolicyStatus_WithFailedStatusUpdate_RecordsWarningEvent(t *te
 		InvalidConfig: false,
 		Descendants:   []state.Descendant[client.Object]{},
 	}
-	reconcileActions := []reconciliation.ReconcileAction{}
+	controllerResources := []reconciliation.ControllerResource{}
 
 	// 2. Act
-	statusmanager.UpdateAuthPolicyStatus(ctx, k8sClient, fakeRecorder, scope, originalAuthPolicy, reconcileActions)
+	statusmanager.UpdateAuthPolicyStatus(ctx, k8sClient, fakeRecorder, scope, originalAuthPolicy, controllerResources)
 
 	// 3. Assert
 	close(fakeRecorder.Events)

--- a/internal/statusmanager/statusmanager_test.go
+++ b/internal/statusmanager/statusmanager_test.go
@@ -9,7 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// mockReconcileAction implements the reconciliation.ReconcileAction interface.
+// mockReconcileAction implements the reconciliation.ControllerResource interface.
 type mockReconcileAction struct {
 	resourceKind string
 	resourceName string
@@ -36,7 +36,7 @@ func (m *mockReconcileAction) Reconcile(
 	return ctrl.Result{}, nil
 }
 
-func createMockReconcileAction(kind, name string, isNil bool) reconciliation.ReconcileAction {
+func createMockReconcileAction(kind, name string, isNil bool) reconciliation.ControllerResource {
 	return &mockReconcileAction{
 		resourceKind: kind,
 		resourceName: name,

--- a/pkg/reconciliation/reconciler.go
+++ b/pkg/reconciliation/reconciler.go
@@ -9,18 +9,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type ReconcileAction interface {
+type ControllerResource interface {
 	Reconcile(ctx context.Context, k8sClient client.Client, scheme *runtime.Scheme) (ctrl.Result, error)
 	GetResourceKind() string
 	GetResourceName() string
 	IsResourceNil() bool
 }
 
-type ReconcileFuncAdapter[T client.Object] struct {
-	Func ReconcileFunc[T]
+type ReconcilerAdapter[T client.Object] struct {
+	Func ResourceReconciler[T]
 }
 
-type ReconcileFunc[T client.Object] struct {
+type ResourceReconciler[T client.Object] struct {
 	ResourceKind    string
 	ResourceName    string
 	DesiredResource *T
@@ -29,7 +29,7 @@ type ReconcileFunc[T client.Object] struct {
 	UpdateFields    func(current T, desired T)
 }
 
-func CountReconciledResources(rfs []ReconcileAction) int {
+func CountNonNilResources(rfs []ControllerResource) int {
 	count := 0
 	for _, rf := range rfs {
 		if !rf.IsResourceNil() {


### PR DESCRIPTION
## Checklist
- [x] Commits follow best practice git conventions
- [x] (not relevant) Introduced dependencies are reviewed
- [ ] (Ztoperator relies on mostly chainsaw testing for this. Introducing more tests is future work) Test coverage is adequate
- [x] (not relevant) New features are documented on `skip.kartverket.no`
- [x] (not relevant) Changes to CRD are documented on `skip.kartverket.no`
- [x] (not relevant) Changes are supported by the `skip-ztoperator` copilot skill
- [x] (not relevant) `setup-skip-action` and `test-authpolicy-action` are compatible with changes
- [x] Code in this PR was written using AI assistance

## Description
This is based on the naming in Accesserator. The two operators now have the same naming scheme and structure. The only differennce is that the actual reoncile logic for Ztoperator happens in /internal/reconciler, while for Accesserator this happens in /pkg/reconciliation. I will rewrite this when introducing owner reference checking for Ztoperator.