### PR TITLE
Respect owner reference on reconcile

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - linters:
+          - goconst
+        path: _test\.go
     paths:
       - third_party$
       - builtin$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,10 @@ linters:
       - linters:
           - goconst
         path: pkg/resourcegenerators/envoyfilter/configpatch
+      - linters:
+          - goconst
+        path: internal/reconciler/resources.go
+        text: AuthorizationPolicy
     paths:
       - third_party$
       - builtin$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,9 @@ linters:
       - linters:
           - goconst
         path: _test\.go
+      - linters:
+          - goconst
+        path: pkg/resourcegenerators/envoyfilter/configpatch
     paths:
       - third_party$
       - builtin$

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ CHAINSAW_VERSION ?= v0.2.15
 CONTROLLER_TOOLS_VERSION ?= v0.21.0
 KUBECTL_VERSION ?= v$(KUBERNETES_VERSION)
 KIND_VERSION ?= v0.31.0
-GOLANGCI_LINT_VERSION ?= v2.10.1
+GOLANGCI_LINT_VERSION ?= v2.12.2
 HELM_VERSION ?= v4.0.0
 
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -2,19 +2,16 @@ package reconciler
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
-	"github.com/kartverket/ztoperator/internal/state"
-	"github.com/kartverket/ztoperator/pkg/log"
 	"github.com/kartverket/ztoperator/pkg/reconciliation"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ControllerResourceAdapter implements the ControllerResource interface.
+// ControllerResourceAdapter implements the reconciliation.ControllerResource interface by delegating to the generic
+// reconciliation engine, which reconciles the resource towards its desired state while respecting AuthPolicy ownership.
 type ControllerResourceAdapter[T client.Object] struct {
 	reconciliation.ReconcilerAdapter[T]
 }
@@ -24,7 +21,7 @@ func (a ControllerResourceAdapter[T]) Reconcile(
 	k8sClient client.Client,
 	scheme *runtime.Scheme,
 ) (ctrl.Result, error) {
-	return reconcileResource(
+	return reconciliation.ReconcileControllerResource(
 		ctx,
 		k8sClient,
 		scheme,
@@ -47,247 +44,4 @@ func (a ControllerResourceAdapter[T]) GetResourceName() string {
 
 func (a ControllerResourceAdapter[T]) IsResourceNil() bool {
 	return a.Func.DesiredResource == nil || reflect.ValueOf(*a.Func.DesiredResource).IsNil()
-}
-
-// reconcileResource handles the lifecycle of a Kubernetes resource:
-// - Deletes it if desired is nil
-// - Creates it if it doesn't exist
-// - Updates it if it exists and differs from desired state.
-func reconcileResource[T client.Object](
-	ctx context.Context,
-	k8sClient client.Client,
-	scheme *runtime.Scheme,
-	scope *state.Scope,
-	resourceKind, resourceName string,
-	desired *T,
-	shouldUpdate func(current, desired T) bool,
-	updateFields func(current, desired T),
-) (ctrl.Result, error) {
-	rLog := log.GetLogger(ctx)
-
-	if desired == nil || reflect.ValueOf(*desired).IsNil() {
-		return deleteResource[T](ctx, k8sClient, scope, resourceKind, resourceName)
-	}
-
-	deReferencedDesired := *desired
-
-	kind := reflect.TypeOf(deReferencedDesired).Elem().Name()
-	current, _ := reflect.New(reflect.TypeOf(deReferencedDesired).Elem()).Interface().(T)
-	rLog.Info(
-		fmt.Sprintf(
-			"Trying to generate %s %s/%s",
-			kind,
-			deReferencedDesired.GetNamespace(),
-			deReferencedDesired.GetName(),
-		),
-	)
-	rLog.Debug(
-		fmt.Sprintf(
-			"Checking if %s %s/%s exists",
-			kind,
-			deReferencedDesired.GetNamespace(),
-			deReferencedDesired.GetName(),
-		),
-	)
-
-	err := k8sClient.Get(ctx, client.ObjectKeyFromObject(deReferencedDesired), current)
-	if apierrors.IsNotFound(err) {
-		return createResource(ctx, k8sClient, scheme, scope, deReferencedDesired, resourceKind, resourceName)
-	}
-
-	if err != nil {
-		errorReason := fmt.Sprintf(
-			"Unable to get %s %s/%s.",
-			kind,
-			deReferencedDesired.GetNamespace(),
-			deReferencedDesired.GetName(),
-		)
-		scope.ReplaceDescendant(deReferencedDesired, &errorReason, nil, resourceKind, resourceName)
-		return ctrl.Result{}, err
-	}
-
-	rLog.Debug(fmt.Sprintf("%s %s/%s exists", kind, deReferencedDesired.GetNamespace(), deReferencedDesired.GetName()))
-	rLog.Debug(
-		fmt.Sprintf(
-			"Determining if %s %s/%s should be updated",
-			kind,
-			deReferencedDesired.GetNamespace(),
-			deReferencedDesired.GetName(),
-		),
-	)
-	if shouldUpdate(current, deReferencedDesired) {
-		rLog.Debug(
-			fmt.Sprintf(
-				"Current %s %s/%s != desired",
-				kind,
-				deReferencedDesired.GetNamespace(),
-				deReferencedDesired.GetName(),
-			),
-		)
-		rLog.Debug(
-			fmt.Sprintf(
-				"Updating current %s %s/%s with desired",
-				kind,
-				deReferencedDesired.GetNamespace(),
-				deReferencedDesired.GetName(),
-			),
-		)
-		updateFields(current, deReferencedDesired)
-
-		if updateErr := k8sClient.Update(ctx, current); updateErr != nil {
-			errorReason := fmt.Sprintf("Unable to update %s %s/%s.", kind, current.GetNamespace(), current.GetName())
-			scope.ReplaceDescendant(current, &errorReason, nil, resourceKind, resourceName)
-			return ctrl.Result{}, updateErr
-		}
-	} else {
-		rLog.Debug(
-			fmt.Sprintf(
-				"Current %s %s/%s == desired. No update needed.",
-				kind,
-				deReferencedDesired.GetNamespace(),
-				deReferencedDesired.GetName(),
-			),
-		)
-	}
-
-	successMessage := fmt.Sprintf("Successfully generated %s %s/%s", kind, current.GetNamespace(), current.GetName())
-	rLog.Info(successMessage)
-	scope.ReplaceDescendant(current, nil, &successMessage, resourceKind, resourceName)
-
-	return ctrl.Result{}, nil
-}
-
-func deleteResource[T client.Object](
-	ctx context.Context,
-	k8sClient client.Client,
-	scope *state.Scope,
-	resourceKind, resourceName string,
-) (ctrl.Result, error) {
-	rLog := log.GetLogger(ctx)
-
-	resourceType := reflect.TypeOf((*T)(nil)).Elem()
-	current, _ := reflect.New(resourceType.Elem()).Interface().(T)
-
-	accessor := current
-	accessor.SetNamespace(scope.AuthPolicy.Namespace)
-	accessor.SetName(resourceName)
-
-	rLog.Info(
-		fmt.Sprintf(
-			"Desired %s %s/%s is nil. Will try to delete it if it exist",
-			resourceKind,
-			accessor.GetNamespace(),
-			accessor.GetName(),
-		),
-	)
-	rLog.Debug(
-		fmt.Sprintf("Checking if %s %s/%s exists", resourceKind, accessor.GetNamespace(), accessor.GetName()),
-	)
-
-	err := k8sClient.Get(ctx, client.ObjectKeyFromObject(accessor), current)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			rLog.Debug(
-				fmt.Sprintf("%s %s/%s already deleted", resourceKind, accessor.GetNamespace(), accessor.GetName()),
-			)
-			return ctrl.Result{}, nil
-		}
-		getErrorMessage := fmt.Sprintf(
-			"Failed to get %s %s/%s when trying to delete it.",
-			resourceKind,
-			accessor.GetNamespace(),
-			accessor.GetName(),
-		)
-		rLog.Error(err, getErrorMessage)
-		scope.ReplaceDescendant(accessor, &getErrorMessage, nil, resourceKind, resourceName)
-		return ctrl.Result{}, err
-	}
-
-	rLog.Info(
-		fmt.Sprintf(
-			"Deleting %s %s/%s as it's no longer desired",
-			resourceKind,
-			accessor.GetNamespace(),
-			accessor.GetName(),
-		),
-	)
-	if deleteErr := k8sClient.Delete(ctx, current); deleteErr != nil {
-		deleteErrorMessage := fmt.Sprintf(
-			"Failed to delete %s %s/%s",
-			resourceKind,
-			accessor.GetNamespace(),
-			accessor.GetName(),
-		)
-		rLog.Error(deleteErr, deleteErrorMessage)
-		scope.ReplaceDescendant(accessor, &deleteErrorMessage, nil, resourceKind, resourceName)
-		return ctrl.Result{}, deleteErr
-	}
-
-	rLog.Debug(
-		fmt.Sprintf("Successfully deleted %s %s/%s", resourceKind, accessor.GetNamespace(), accessor.GetName()),
-	)
-	successMsg := fmt.Sprintf(
-		"Deleted %s %s/%s as it is no longer desired.",
-		resourceKind,
-		accessor.GetNamespace(),
-		accessor.GetName(),
-	)
-	scope.ReplaceDescendant(accessor, nil, &successMsg, resourceKind, resourceName)
-	return ctrl.Result{}, nil
-}
-
-func createResource[T client.Object](
-	ctx context.Context,
-	k8sClient client.Client,
-	scheme *runtime.Scheme,
-	scope *state.Scope,
-	desired T,
-	resourceKind, resourceName string,
-) (ctrl.Result, error) {
-	rLog := log.GetLogger(ctx)
-	kind := reflect.TypeOf(desired).Elem().Name()
-
-	rLog.Debug(
-		fmt.Sprintf(
-			"%s %s/%s does not exist",
-			kind,
-			desired.GetNamespace(),
-			desired.GetName(),
-		),
-	)
-
-	if controllerRefErr := ctrl.SetControllerReference(&scope.AuthPolicy, desired, scheme); controllerRefErr != nil {
-		errorReason := fmt.Sprintf(
-			"Unable to set AuthPolicy ownerReference on %s %s/%s.",
-			kind,
-			desired.GetNamespace(),
-			desired.GetName(),
-		)
-		scope.ReplaceDescendant(desired, &errorReason, nil, resourceKind, resourceName)
-		return ctrl.Result{}, controllerRefErr
-	}
-
-	rLog.Info(
-		fmt.Sprintf("Creating %s %s/%s", kind, desired.GetNamespace(), desired.GetName()),
-	)
-	if createErr := k8sClient.Create(ctx, desired); createErr != nil {
-		errorReason := fmt.Sprintf(
-			"Unable to create %s %s/%s",
-			kind,
-			desired.GetNamespace(),
-			desired.GetName(),
-		)
-		scope.ReplaceDescendant(desired, &errorReason, nil, resourceKind, resourceName)
-		return ctrl.Result{}, createErr
-	}
-
-	successMessage := fmt.Sprintf(
-		"Successfully created %s %s/%s.",
-		kind,
-		desired.GetNamespace(),
-		desired.GetName(),
-	)
-	scope.ReplaceDescendant(desired, nil, &successMessage, resourceKind, resourceName)
-
-	return ctrl.Result{}, nil
 }

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -1,0 +1,316 @@
+package reconciler_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	ztoperatorv1alpha1 "github.com/kartverket/ztoperator/api/v1alpha1"
+	"github.com/kartverket/ztoperator/internal/reconciler"
+	"github.com/kartverket/ztoperator/internal/state"
+	"github.com/kartverket/ztoperator/pkg/reconciliation"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("ControllerResourceAdapter", func() {
+	var (
+		testNamespace string
+		scope         *state.Scope
+	)
+
+	// secretShouldUpdate / secretUpdateFields mimic the production callbacks closely enough to exercise the
+	// reconciliation engine: a Secret needs updating when its data differs from desired.
+	secretShouldUpdate := func(current, desired *corev1.Secret) bool {
+		return !bytes.Equal(current.Data["token"], desired.Data["token"])
+	}
+	secretUpdateFields := func(current, desired *corev1.Secret) {
+		current.Data = desired.Data
+	}
+
+	newSecret := func(name string, token string) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{"token": []byte(token)},
+			Type: corev1.SecretTypeOpaque,
+		}
+	}
+
+	BeforeEach(func() {
+		testNamespace = fmt.Sprintf("test-reconciler-%d", time.Now().UnixNano())
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testNamespace,
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+
+		// A minimal scope whose AuthPolicy acts as the owner of reconciled resources.
+		scope = &state.Scope{
+			AuthPolicy: ztoperatorv1alpha1.AuthPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-authpolicy",
+					Namespace: testNamespace,
+					UID:       "test-uid-12345",
+				},
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testNamespace,
+			},
+		}
+		_ = k8sClient.Delete(ctx, ns)
+	})
+
+	Describe("GetResourceKind", func() {
+		It("should return the correct resource kind", func() {
+			adapter := reconciler.ControllerResourceAdapter[*corev1.Secret]{
+				ReconcilerAdapter: reconciliation.ReconcilerAdapter[*corev1.Secret]{
+					Func: reconciliation.ResourceReconciler[*corev1.Secret]{
+						ResourceKind: "Secret",
+						ResourceName: "test-secret",
+					},
+				},
+			}
+
+			Expect(adapter.GetResourceKind()).To(Equal("Secret"))
+		})
+	})
+
+	Describe("GetResourceName", func() {
+		It("should return the correct resource name", func() {
+			adapter := reconciler.ControllerResourceAdapter[*corev1.Secret]{
+				ReconcilerAdapter: reconciliation.ReconcilerAdapter[*corev1.Secret]{
+					Func: reconciliation.ResourceReconciler[*corev1.Secret]{
+						ResourceKind: "Secret",
+						ResourceName: "my-test-secret",
+					},
+				},
+			}
+
+			Expect(adapter.GetResourceName()).To(Equal("my-test-secret"))
+		})
+	})
+
+	Describe("IsResourceNil", func() {
+		It("should return true when DesiredResource is nil", func() {
+			adapter := reconciler.ControllerResourceAdapter[*corev1.Secret]{
+				ReconcilerAdapter: reconciliation.ReconcilerAdapter[*corev1.Secret]{
+					Func: reconciliation.ResourceReconciler[*corev1.Secret]{
+						ResourceKind:    "Secret",
+						ResourceName:    "test-secret",
+						DesiredResource: nil,
+					},
+				},
+			}
+
+			Expect(adapter.IsResourceNil()).To(BeTrue())
+		})
+
+		It("should return true when DesiredResource points to nil", func() {
+			var nilSecret *corev1.Secret
+			adapter := reconciler.ControllerResourceAdapter[*corev1.Secret]{
+				ReconcilerAdapter: reconciliation.ReconcilerAdapter[*corev1.Secret]{
+					Func: reconciliation.ResourceReconciler[*corev1.Secret]{
+						ResourceKind:    "Secret",
+						ResourceName:    "test-secret",
+						DesiredResource: &nilSecret,
+					},
+				},
+			}
+
+			Expect(adapter.IsResourceNil()).To(BeTrue())
+		})
+
+		It("should return false when DesiredResource is not nil", func() {
+			secret := newSecret("test-secret", "token")
+			adapter := reconciler.ControllerResourceAdapter[*corev1.Secret]{
+				ReconcilerAdapter: reconciliation.ReconcilerAdapter[*corev1.Secret]{
+					Func: reconciliation.ResourceReconciler[*corev1.Secret]{
+						ResourceKind:    "Secret",
+						ResourceName:    "test-secret",
+						DesiredResource: &secret,
+					},
+				},
+			}
+
+			Expect(adapter.IsResourceNil()).To(BeFalse())
+		})
+	})
+
+	Describe("Reconcile", func() {
+		newAdapter := func(name string, desired *corev1.Secret) reconciler.ControllerResourceAdapter[*corev1.Secret] {
+			return reconciler.ControllerResourceAdapter[*corev1.Secret]{
+				ReconcilerAdapter: reconciliation.ReconcilerAdapter[*corev1.Secret]{
+					Func: reconciliation.ResourceReconciler[*corev1.Secret]{
+						ResourceKind:    "Secret",
+						ResourceName:    name,
+						DesiredResource: &desired,
+						Scope:           scope,
+						ShouldUpdate:    secretShouldUpdate,
+						UpdateFields:    secretUpdateFields,
+					},
+				},
+			}
+		}
+
+		It("should create a resource when it does not exist", func() {
+			desired := newSecret("test-secret-create", "first-token")
+			adapter := newAdapter(desired.Name, desired)
+
+			result, err := adapter.Reconcile(ctx, k8sClient, scheme.Scheme)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			createdSecret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      desired.Name,
+				Namespace: testNamespace,
+			}, createdSecret)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createdSecret.Data["token"]).To(Equal([]byte("first-token")))
+			Expect(metav1.IsControlledBy(createdSecret, &scope.AuthPolicy)).To(BeTrue())
+		})
+
+		It("should NOT update a resource when it exists and needs updating, but is not owned by AuthPolicy", func() {
+			secretName := "test-secret-update"
+			existing := newSecret(secretName, "old-token")
+			Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+
+			desired := newSecret(secretName, "new-token")
+			adapter := newAdapter(secretName, desired)
+
+			result, err := adapter.Reconcile(ctx, k8sClient, scheme.Scheme)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot update"))
+			Expect(err.Error()).To(ContainSubstring("as it is not owned by AuthPolicy"))
+			Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+
+			// Verify the resource was left untouched.
+			updated := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      secretName,
+				Namespace: testNamespace,
+			}, updated)).To(Succeed())
+			Expect(updated.Data["token"]).To(Equal([]byte("old-token")))
+		})
+
+		It("should update a resource when it exists, is owned by AuthPolicy and needs updating", func() {
+			secretName := "test-secret-update"
+			existing := newSecret(secretName, "old-token")
+			Expect(ctrl.SetControllerReference(&scope.AuthPolicy, existing, scheme.Scheme)).To(Succeed())
+			Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+
+			desired := newSecret(secretName, "new-token")
+			adapter := newAdapter(secretName, desired)
+
+			result, err := adapter.Reconcile(ctx, k8sClient, scheme.Scheme)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			updated := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      secretName,
+				Namespace: testNamespace,
+			}, updated)).To(Succeed())
+			Expect(updated.Data["token"]).To(Equal([]byte("new-token")))
+		})
+
+		It("should not update a resource when no changes are needed", func() {
+			secretName := "test-secret-noupdate"
+			existing := newSecret(secretName, "same-token")
+			Expect(ctrl.SetControllerReference(&scope.AuthPolicy, existing, scheme.Scheme)).To(Succeed())
+			Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+
+			var beforeSecret corev1.Secret
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      secretName,
+				Namespace: testNamespace,
+			}, &beforeSecret)).To(Succeed())
+			resourceVersionBefore := beforeSecret.ResourceVersion
+
+			desired := newSecret(secretName, "same-token")
+			adapter := newAdapter(secretName, desired)
+
+			result, err := adapter.Reconcile(ctx, k8sClient, scheme.Scheme)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			var afterSecret corev1.Secret
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      secretName,
+				Namespace: testNamespace,
+			}, &afterSecret)).To(Succeed())
+			Expect(afterSecret.ResourceVersion).To(Equal(resourceVersionBefore))
+		})
+
+		It("should NOT delete a resource when desired is nil, the resource exists, but the resource is NOT owned by AuthPolicy", func() {
+			secretName := "test-secret-delete"
+			existing := newSecret(secretName, "to-be-deleted")
+			Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+
+			var nilSecret *corev1.Secret
+			adapter := newAdapter(secretName, nilSecret)
+
+			result, err := adapter.Reconcile(ctx, k8sClient, scheme.Scheme)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			Eventually(func() bool {
+				notDeleted := &corev1.Secret{}
+				err := k8sClient.Get(context.Background(), types.NamespacedName{
+					Name:      secretName,
+					Namespace: testNamespace,
+				}, notDeleted)
+				return err == nil
+			}).Should(BeTrue())
+		})
+
+		It("should delete a resource when desired is nil, the resource exists, and the resource is owned by AuthPolicy", func() {
+			secretName := "test-secret-delete"
+			existing := newSecret(secretName, "to-be-deleted")
+			Expect(ctrl.SetControllerReference(&scope.AuthPolicy, existing, scheme.Scheme)).To(Succeed())
+			Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+
+			var nilSecret *corev1.Secret
+			adapter := newAdapter(secretName, nilSecret)
+
+			result, err := adapter.Reconcile(ctx, k8sClient, scheme.Scheme)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			Eventually(func() bool {
+				deleted := &corev1.Secret{}
+				err := k8sClient.Get(context.Background(), types.NamespacedName{
+					Name:      secretName,
+					Namespace: testNamespace,
+				}, deleted)
+				return err != nil && errors.IsNotFound(err)
+			}).Should(BeTrue())
+		})
+
+		It("should handle reconcile when desired is nil and resource does not exist", func() {
+			var nilSecret *corev1.Secret
+			adapter := newAdapter("non-existent-secret", nilSecret)
+
+			result, err := adapter.Reconcile(ctx, k8sClient, scheme.Scheme)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+		})
+	})
+})

--- a/internal/reconciler/resources.go
+++ b/internal/reconciler/resources.go
@@ -51,21 +51,21 @@ func secretResource(scope *state.Scope) ControllerResourceAdapter[*v1.Secret] {
 				ResourceName:    scope.AutoLoginConfig.EnvoySecretName,
 				DesiredResource: helperfunctions.Ptr(desiredResource),
 				Scope:           scope,
-				ShouldUpdate:    secretShouldUpdate,
-				UpdateFields:    secretUpdateFields,
+				ShouldUpdate:    SecretShouldUpdate,
+				UpdateFields:    SecretUpdateFields,
 			},
 		},
 	}
 }
 
-func secretShouldUpdate(current, desired *v1.Secret) bool {
+func SecretShouldUpdate(current, desired *v1.Secret) bool {
 	desiredTokenSecret, hasDesired := desired.Data[configpatch.TokenSecretFileName]
 	currentTokenSecret, hasCurrent := current.Data[configpatch.TokenSecretFileName]
 	return !hasDesired || !hasCurrent || !bytes.Equal(currentTokenSecret, desiredTokenSecret) ||
 		labelsNeedUpdate(current, desired)
 }
 
-func secretUpdateFields(current, desired *v1.Secret) {
+func SecretUpdateFields(current, desired *v1.Secret) {
 	current.Data = desired.Data
 	current.Labels = desired.Labels
 }
@@ -88,14 +88,14 @@ func envoyFilterResource(scope *state.Scope) ControllerResourceAdapter[*v1alpha4
 				ResourceName:    autoLoginEnvoyFilterName,
 				DesiredResource: helperfunctions.Ptr(desiredResource),
 				Scope:           scope,
-				ShouldUpdate:    envoyFilterShouldUpdate,
-				UpdateFields:    envoyFilterUpdateFields,
+				ShouldUpdate:    EnvoyFilterShouldUpdate,
+				UpdateFields:    EnvoyFilterUpdateFields,
 			},
 		},
 	}
 }
 
-func envoyFilterShouldUpdate(current, desired *v1alpha4.EnvoyFilter) bool {
+func EnvoyFilterShouldUpdate(current, desired *v1alpha4.EnvoyFilter) bool {
 	return !reflect.DeepEqual(
 		current.Spec.GetWorkloadSelector(),
 		desired.Spec.GetWorkloadSelector(),
@@ -106,7 +106,7 @@ func envoyFilterShouldUpdate(current, desired *v1alpha4.EnvoyFilter) bool {
 		labelsNeedUpdate(current, desired)
 }
 
-func envoyFilterUpdateFields(current, desired *v1alpha4.EnvoyFilter) {
+func EnvoyFilterUpdateFields(current, desired *v1alpha4.EnvoyFilter) {
 	current.Spec.WorkloadSelector = desired.Spec.GetWorkloadSelector()
 	current.Spec.ConfigPatches = desired.Spec.GetConfigPatches()
 	current.Labels = desired.Labels
@@ -132,20 +132,20 @@ func requestAuthenticationResource(
 				ResourceName:    requestAuthenticationName,
 				DesiredResource: helperfunctions.Ptr(desiredResource),
 				Scope:           scope,
-				ShouldUpdate:    requestAuthenticationShouldUpdate,
-				UpdateFields:    requestAuthenticationUpdateFields,
+				ShouldUpdate:    RequestAuthenticationShouldUpdate,
+				UpdateFields:    RequestAuthenticationUpdateFields,
 			},
 		},
 	}
 }
 
-func requestAuthenticationShouldUpdate(current, desired *istioclientsecurityv1.RequestAuthentication) bool {
+func RequestAuthenticationShouldUpdate(current, desired *istioclientsecurityv1.RequestAuthentication) bool {
 	return !reflect.DeepEqual(current.Spec.GetSelector(), desired.Spec.GetSelector()) ||
 		!reflect.DeepEqual(current.Spec.GetJwtRules(), desired.Spec.GetJwtRules()) ||
 		labelsNeedUpdate(current, desired)
 }
 
-func requestAuthenticationUpdateFields(current, desired *istioclientsecurityv1.RequestAuthentication) {
+func RequestAuthenticationUpdateFields(current, desired *istioclientsecurityv1.RequestAuthentication) {
 	current.Spec.Selector = desired.Spec.GetSelector()
 	current.Spec.JwtRules = desired.Spec.GetJwtRules()
 	current.Labels = desired.Labels
@@ -172,8 +172,8 @@ func denyAuthorizationPolicyResource(
 				ResourceName:    denyAuthorizationPolicyName,
 				DesiredResource: helperfunctions.Ptr(desiredResource),
 				Scope:           scope,
-				ShouldUpdate:    authorizationPolicyShouldUpdate,
-				UpdateFields:    authorizationPolicyUpdateFields,
+				ShouldUpdate:    AuthorizationPolicyShouldUpdate,
+				UpdateFields:    AuthorizationPolicyUpdateFields,
 			},
 		},
 	}
@@ -200,8 +200,8 @@ func ignoreAuthorizationPolicyResource(
 				ResourceName:    ignoreAuthAuthorizationPolicyName,
 				DesiredResource: helperfunctions.Ptr(desiredResource),
 				Scope:           scope,
-				ShouldUpdate:    authorizationPolicyShouldUpdate,
-				UpdateFields:    authorizationPolicyUpdateFields,
+				ShouldUpdate:    AuthorizationPolicyShouldUpdate,
+				UpdateFields:    AuthorizationPolicyUpdateFields,
 			},
 		},
 	}
@@ -228,20 +228,20 @@ func requireAuthorizationPolicyResource(
 				ResourceName:    requireAuthAuthorizationPolicyName,
 				DesiredResource: helperfunctions.Ptr(desiredResource),
 				Scope:           scope,
-				ShouldUpdate:    authorizationPolicyShouldUpdate,
-				UpdateFields:    authorizationPolicyUpdateFields,
+				ShouldUpdate:    AuthorizationPolicyShouldUpdate,
+				UpdateFields:    AuthorizationPolicyUpdateFields,
 			},
 		},
 	}
 }
 
-func authorizationPolicyShouldUpdate(current, desired *istioclientsecurityv1.AuthorizationPolicy) bool {
+func AuthorizationPolicyShouldUpdate(current, desired *istioclientsecurityv1.AuthorizationPolicy) bool {
 	return !reflect.DeepEqual(current.Spec.GetSelector(), desired.Spec.GetSelector()) ||
 		!reflect.DeepEqual(current.Spec.GetRules(), desired.Spec.GetRules()) ||
 		labelsNeedUpdate(current, desired)
 }
 
-func authorizationPolicyUpdateFields(current, desired *istioclientsecurityv1.AuthorizationPolicy) {
+func AuthorizationPolicyUpdateFields(current, desired *istioclientsecurityv1.AuthorizationPolicy) {
 	current.Spec.Selector = desired.Spec.GetSelector()
 	current.Spec.Rules = desired.Spec.GetRules()
 	current.Labels = desired.Labels

--- a/internal/reconciler/resources_test.go
+++ b/internal/reconciler/resources_test.go
@@ -1,0 +1,484 @@
+package reconciler_test
+
+import (
+	"fmt"
+	"time"
+
+	ztoperatorv1alpha1 "github.com/kartverket/ztoperator/api/v1alpha1"
+	"github.com/kartverket/ztoperator/internal/names"
+	"github.com/kartverket/ztoperator/internal/reconciler"
+	"github.com/kartverket/ztoperator/internal/state"
+	"github.com/kartverket/ztoperator/pkg/helperfunctions"
+	"github.com/kartverket/ztoperator/pkg/labels"
+	"github.com/kartverket/ztoperator/pkg/reconciliation"
+	"github.com/kartverket/ztoperator/pkg/resourcegenerators/envoyfilter/configpatch"
+	"github.com/kartverket/ztoperator/pkg/resourcegenerators/secret"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	istioapinetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
+	istioapisecurityv1 "istio.io/api/security/v1"
+	istioapisecurityv1beta1 "istio.io/api/security/v1beta1"
+	istioapitypev1beta1 "istio.io/api/type/v1beta1"
+	v1alpha4 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	istioclientsecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("ControllerResources", func() {
+	const authPolicyName = "test-app"
+
+	scopeFor := func(namespace string) *state.Scope {
+		return &state.Scope{
+			AuthPolicy: ztoperatorv1alpha1.AuthPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      authPolicyName,
+					Namespace: namespace,
+				},
+			},
+			AutoLoginConfig: state.AutoLoginConfig{
+				EnvoySecretName: names.EnvoySecret(authPolicyName),
+			},
+		}
+	}
+
+	It("returns resources with correct kinds", func() {
+		resources := reconciler.ControllerResources(scopeFor("some-namespace"))
+		kinds := make([]string, len(resources))
+		for i, r := range resources {
+			kinds[i] = r.GetResourceKind()
+		}
+		Expect(kinds).To(
+			ConsistOf(
+				"Secret",
+				"EnvoyFilter",
+				"RequestAuthentication",
+				"AuthorizationPolicy",
+				"AuthorizationPolicy",
+				"AuthorizationPolicy",
+			),
+		)
+	})
+
+	It("returns resources with correct names", func() {
+		resources := reconciler.ControllerResources(scopeFor("some-namespace"))
+
+		resourceKindsAndNames := make([]string, len(resources))
+		for i, r := range resources {
+			resourceKindsAndNames[i] = fmt.Sprintf("%s/%s", r.GetResourceKind(), r.GetResourceName())
+		}
+
+		Expect(resourceKindsAndNames).To(
+			ConsistOf(
+				fmt.Sprintf("%s/%s", "Secret", names.EnvoySecret(authPolicyName)),
+				fmt.Sprintf("%s/%s", "EnvoyFilter", names.EnvoyFilter(authPolicyName)),
+				fmt.Sprintf("%s/%s", "RequestAuthentication", authPolicyName),
+				fmt.Sprintf("%s/%s", "AuthorizationPolicy", names.DenyPolicy(authPolicyName)),
+				fmt.Sprintf("%s/%s", "AuthorizationPolicy", names.IgnorePolicy(authPolicyName)),
+				fmt.Sprintf("%s/%s", "AuthorizationPolicy", names.RequirePolicy(authPolicyName)),
+			),
+		)
+	})
+})
+
+var _ = Describe("auto-login Secret reconciliation", func() {
+	var (
+		testNamespace string
+		scope         *state.Scope
+	)
+
+	// buildSecretAdapter wires up the auto-login Secret adapter exactly like the production factory does: the desired
+	// state comes from the real generator and ownership is enforced by the shared reconciliation engine.
+	buildSecretAdapter := func() reconciler.ControllerResourceAdapter[*corev1.Secret] {
+		objectMeta := metav1.ObjectMeta{
+			Name:      scope.AutoLoginConfig.EnvoySecretName,
+			Namespace: scope.AuthPolicy.Namespace,
+			Labels:    labels.AuthPolicyStandardLabels(),
+		}
+		desired := secret.GetDesired(scope, objectMeta)
+		Expect(desired).NotTo(BeNil())
+
+		return reconciler.ControllerResourceAdapter[*corev1.Secret]{
+			ReconcilerAdapter: reconciliation.ReconcilerAdapter[*corev1.Secret]{
+				Func: reconciliation.ResourceReconciler[*corev1.Secret]{
+					ResourceKind:    "Secret",
+					ResourceName:    objectMeta.Name,
+					DesiredResource: &desired,
+					Scope:           scope,
+					ShouldUpdate:    reconciler.SecretShouldUpdate,
+					UpdateFields:    reconciler.SecretUpdateFields,
+				},
+			},
+		}
+	}
+
+	BeforeEach(func() {
+		testNamespace = fmt.Sprintf("test-secret-resources-%d", time.Now().UnixNano())
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testNamespace,
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+
+		scope = &state.Scope{
+			AuthPolicy: ztoperatorv1alpha1.AuthPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: testNamespace,
+					UID:       "test-uid-secret",
+				},
+				Spec: ztoperatorv1alpha1.AuthPolicySpec{
+					Enabled:   true,
+					AutoLogin: &ztoperatorv1alpha1.AutoLogin{Enabled: true},
+				},
+			},
+			OAuthCredentials: state.OAuthCredentials{
+				ClientSecret: helperfunctions.Ptr("super-secret"),
+			},
+			AutoLoginConfig: state.AutoLoginConfig{
+				EnvoySecretName: names.EnvoySecret("test-app"),
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testNamespace,
+			},
+		}
+		_ = k8sClient.Delete(ctx, ns)
+	})
+
+	It("creates a Secret when it does not exist", func() {
+		adapter := buildSecretAdapter()
+
+		_, err := adapter.Reconcile(ctx, k8sClient, scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		createdSecret := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name:      adapter.GetResourceName(),
+			Namespace: testNamespace,
+		}, createdSecret)).To(Succeed())
+		Expect(createdSecret.Data).To(HaveKey(configpatch.TokenSecretFileName))
+		Expect(createdSecret.Labels).To(SatisfyAll(
+			HaveKeyWithValue(labels.ManagedByLabelKey, labels.ManagedByLabelValue),
+			HaveKeyWithValue(labels.ControllerLabelKey, labels.AuthPolicyControllerLabelValue),
+		))
+		Expect(metav1.IsControlledBy(createdSecret, &scope.AuthPolicy)).To(BeTrue())
+	})
+
+	It("does NOT update a Secret when it needs updating but is not owned by AuthPolicy", func() {
+		existing := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      scope.AutoLoginConfig.EnvoySecretName,
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{"placeholder": []byte("value")},
+			Type: corev1.SecretTypeOpaque,
+		}
+		Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+
+		adapter := buildSecretAdapter()
+
+		_, err := adapter.Reconcile(ctx, k8sClient, scheme.Scheme)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cannot update"))
+		Expect(err.Error()).To(ContainSubstring("as it is not owned by AuthPolicy"))
+
+		updated := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name:      scope.AutoLoginConfig.EnvoySecretName,
+			Namespace: testNamespace,
+		}, updated)).To(Succeed())
+		Expect(updated.Data).ToNot(HaveKey(configpatch.TokenSecretFileName))
+	})
+
+	It("updates a Secret when it needs updating and is owned by AuthPolicy", func() {
+		existing := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      scope.AutoLoginConfig.EnvoySecretName,
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{"placeholder": []byte("value")},
+			Type: corev1.SecretTypeOpaque,
+		}
+		Expect(ctrl.SetControllerReference(&scope.AuthPolicy, existing, scheme.Scheme)).To(Succeed())
+		Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+
+		adapter := buildSecretAdapter()
+
+		_, err := adapter.Reconcile(ctx, k8sClient, scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name:      scope.AutoLoginConfig.EnvoySecretName,
+			Namespace: testNamespace,
+		}, updated)).To(Succeed())
+		Expect(updated.Data).To(HaveKey(configpatch.TokenSecretFileName))
+	})
+
+	It("does not update a Secret when the OAuth client secret is unchanged", func() {
+		Expect(buildSecretAdapter().Reconcile(ctx, k8sClient, scheme.Scheme)).Error().NotTo(HaveOccurred())
+
+		before := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name:      scope.AutoLoginConfig.EnvoySecretName,
+			Namespace: testNamespace,
+		}, before)).To(Succeed())
+		rvBefore := before.ResourceVersion
+
+		// A fresh adapter regenerates the desired Secret (including a new random HMAC key), but the OAuth client
+		// secret is unchanged, so no update should be performed.
+		Expect(buildSecretAdapter().Reconcile(ctx, k8sClient, scheme.Scheme)).Error().NotTo(HaveOccurred())
+
+		after := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name:      scope.AutoLoginConfig.EnvoySecretName,
+			Namespace: testNamespace,
+		}, after)).To(Succeed())
+		Expect(after.ResourceVersion).To(Equal(rvBefore))
+	})
+})
+
+var _ = Describe("SecretShouldUpdate", func() {
+	secretWithToken := func(token string, lbls map[string]string) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Labels: lbls},
+			Data:       map[string][]byte{configpatch.TokenSecretFileName: []byte(token)},
+		}
+	}
+
+	It("returns false when the token secret and labels are unchanged", func() {
+		current := secretWithToken("same", labels.AuthPolicyStandardLabels())
+		desired := secretWithToken("same", labels.AuthPolicyStandardLabels())
+		Expect(reconciler.SecretShouldUpdate(current, desired)).To(BeFalse())
+	})
+
+	It("returns true when the token secret value differs", func() {
+		current := secretWithToken("old", labels.AuthPolicyStandardLabels())
+		desired := secretWithToken("new", labels.AuthPolicyStandardLabels())
+		Expect(reconciler.SecretShouldUpdate(current, desired)).To(BeTrue())
+	})
+
+	It("returns true when the current Secret is missing the token key", func() {
+		current := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Labels: labels.AuthPolicyStandardLabels()}}
+		desired := secretWithToken("token", labels.AuthPolicyStandardLabels())
+		Expect(reconciler.SecretShouldUpdate(current, desired)).To(BeTrue())
+	})
+
+	It("returns true when a desired label is missing on current", func() {
+		current := secretWithToken("same", nil)
+		desired := secretWithToken("same", labels.AuthPolicyStandardLabels())
+		Expect(reconciler.SecretShouldUpdate(current, desired)).To(BeTrue())
+	})
+
+	It("returns false when desired labels are a subset of current labels", func() {
+		currentLabels := labels.AuthPolicyStandardLabels()
+		currentLabels["custom.example.com/team"] = "platform"
+		current := secretWithToken("same", currentLabels)
+		desired := secretWithToken("same", labels.AuthPolicyStandardLabels())
+		Expect(reconciler.SecretShouldUpdate(current, desired)).To(BeFalse())
+	})
+})
+
+var _ = Describe("EnvoyFilterShouldUpdate", func() {
+	It("returns false when current and desired are equal", func() {
+		Expect(reconciler.EnvoyFilterShouldUpdate(&v1alpha4.EnvoyFilter{}, &v1alpha4.EnvoyFilter{})).To(BeFalse())
+	})
+
+	It("returns true when the workload selector differs", func() {
+		current := &v1alpha4.EnvoyFilter{}
+		desired := &v1alpha4.EnvoyFilter{
+			Spec: istioapinetworkingv1alpha3.EnvoyFilter{
+				WorkloadSelector: &istioapinetworkingv1alpha3.WorkloadSelector{
+					Labels: map[string]string{"app": "test"},
+				},
+			},
+		}
+		Expect(reconciler.EnvoyFilterShouldUpdate(current, desired)).To(BeTrue())
+	})
+
+	It("returns true when the config patches differ", func() {
+		current := &v1alpha4.EnvoyFilter{}
+		desired := &v1alpha4.EnvoyFilter{
+			Spec: istioapinetworkingv1alpha3.EnvoyFilter{
+				ConfigPatches: []*istioapinetworkingv1alpha3.EnvoyFilter_EnvoyConfigObjectPatch{
+					{ApplyTo: istioapinetworkingv1alpha3.EnvoyFilter_HTTP_FILTER},
+				},
+			},
+		}
+		Expect(reconciler.EnvoyFilterShouldUpdate(current, desired)).To(BeTrue())
+	})
+
+	It("returns true when a desired label is missing on current", func() {
+		current := &v1alpha4.EnvoyFilter{}
+		desired := &v1alpha4.EnvoyFilter{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labels.ManagedByLabelKey: labels.ManagedByLabelValue}},
+		}
+		Expect(reconciler.EnvoyFilterShouldUpdate(current, desired)).To(BeTrue())
+	})
+})
+
+var _ = Describe("RequestAuthenticationShouldUpdate", func() {
+	It("returns false when current and desired are equal", func() {
+		Expect(reconciler.RequestAuthenticationShouldUpdate(
+			&istioclientsecurityv1.RequestAuthentication{},
+			&istioclientsecurityv1.RequestAuthentication{},
+		)).To(BeFalse())
+	})
+
+	It("returns true when the selector differs", func() {
+		current := &istioclientsecurityv1.RequestAuthentication{}
+		desired := &istioclientsecurityv1.RequestAuthentication{
+			Spec: istioapisecurityv1.RequestAuthentication{
+				Selector: &istioapitypev1beta1.WorkloadSelector{MatchLabels: map[string]string{"app": "test"}},
+			},
+		}
+		Expect(reconciler.RequestAuthenticationShouldUpdate(current, desired)).To(BeTrue())
+	})
+
+	It("returns true when the JWT rules differ", func() {
+		current := &istioclientsecurityv1.RequestAuthentication{}
+		desired := &istioclientsecurityv1.RequestAuthentication{
+			Spec: istioapisecurityv1.RequestAuthentication{
+				JwtRules: []*istioapisecurityv1.JWTRule{{Issuer: "https://issuer.example.com"}},
+			},
+		}
+		Expect(reconciler.RequestAuthenticationShouldUpdate(current, desired)).To(BeTrue())
+	})
+
+	It("returns true when a desired label is missing on current", func() {
+		current := &istioclientsecurityv1.RequestAuthentication{}
+		desired := &istioclientsecurityv1.RequestAuthentication{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labels.ManagedByLabelKey: labels.ManagedByLabelValue}},
+		}
+		Expect(reconciler.RequestAuthenticationShouldUpdate(current, desired)).To(BeTrue())
+	})
+})
+
+var _ = Describe("AuthorizationPolicyShouldUpdate", func() {
+	It("returns false when current and desired are equal", func() {
+		Expect(reconciler.AuthorizationPolicyShouldUpdate(
+			&istioclientsecurityv1.AuthorizationPolicy{},
+			&istioclientsecurityv1.AuthorizationPolicy{},
+		)).To(BeFalse())
+	})
+
+	It("returns true when the selector differs", func() {
+		current := &istioclientsecurityv1.AuthorizationPolicy{}
+		desired := &istioclientsecurityv1.AuthorizationPolicy{
+			Spec: istioapisecurityv1beta1.AuthorizationPolicy{
+				Selector: &istioapitypev1beta1.WorkloadSelector{MatchLabels: map[string]string{"app": "test"}},
+			},
+		}
+		Expect(reconciler.AuthorizationPolicyShouldUpdate(current, desired)).To(BeTrue())
+	})
+
+	It("returns true when the rules differ", func() {
+		current := &istioclientsecurityv1.AuthorizationPolicy{}
+		desired := &istioclientsecurityv1.AuthorizationPolicy{
+			Spec: istioapisecurityv1beta1.AuthorizationPolicy{
+				Rules: []*istioapisecurityv1beta1.Rule{{}},
+			},
+		}
+		Expect(reconciler.AuthorizationPolicyShouldUpdate(current, desired)).To(BeTrue())
+	})
+
+	It("returns true when a desired label is missing on current", func() {
+		current := &istioclientsecurityv1.AuthorizationPolicy{}
+		desired := &istioclientsecurityv1.AuthorizationPolicy{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labels.ManagedByLabelKey: labels.ManagedByLabelValue}},
+		}
+		Expect(reconciler.AuthorizationPolicyShouldUpdate(current, desired)).To(BeTrue())
+	})
+})
+
+var _ = Describe("SecretUpdateFields", func() {
+	It("copies the data and labels from desired to current and leaves the type untouched", func() {
+		current := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"stale": "label"}},
+			Data:       map[string][]byte{"old": []byte("value")},
+			Type:       corev1.SecretTypeOpaque,
+		}
+		desired := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels.AuthPolicyStandardLabels()},
+			Data:       map[string][]byte{"new": []byte("value")},
+		}
+
+		reconciler.SecretUpdateFields(current, desired)
+
+		Expect(current.Data).To(Equal(desired.Data))
+		Expect(current.Labels).To(Equal(desired.Labels))
+		// Type is intentionally not managed by the update.
+		Expect(current.Type).To(Equal(corev1.SecretTypeOpaque))
+	})
+})
+
+var _ = Describe("EnvoyFilterUpdateFields", func() {
+	It("copies the workload selector, config patches and labels from desired to current", func() {
+		current := &v1alpha4.EnvoyFilter{}
+		desired := &v1alpha4.EnvoyFilter{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels.AuthPolicyStandardLabels()},
+			Spec: istioapinetworkingv1alpha3.EnvoyFilter{
+				WorkloadSelector: &istioapinetworkingv1alpha3.WorkloadSelector{
+					Labels: map[string]string{"app": "test"},
+				},
+				ConfigPatches: []*istioapinetworkingv1alpha3.EnvoyFilter_EnvoyConfigObjectPatch{
+					{ApplyTo: istioapinetworkingv1alpha3.EnvoyFilter_HTTP_FILTER},
+				},
+			},
+		}
+
+		reconciler.EnvoyFilterUpdateFields(current, desired)
+
+		Expect(current.Spec.GetWorkloadSelector()).To(Equal(desired.Spec.GetWorkloadSelector()))
+		Expect(current.Spec.GetConfigPatches()).To(Equal(desired.Spec.GetConfigPatches()))
+		Expect(current.Labels).To(Equal(desired.Labels))
+	})
+})
+
+var _ = Describe("RequestAuthenticationUpdateFields", func() {
+	It("copies the selector, JWT rules and labels from desired to current", func() {
+		current := &istioclientsecurityv1.RequestAuthentication{}
+		desired := &istioclientsecurityv1.RequestAuthentication{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels.AuthPolicyStandardLabels()},
+			Spec: istioapisecurityv1.RequestAuthentication{
+				Selector: &istioapitypev1beta1.WorkloadSelector{MatchLabels: map[string]string{"app": "test"}},
+				JwtRules: []*istioapisecurityv1.JWTRule{{Issuer: "https://issuer.example.com"}},
+			},
+		}
+
+		reconciler.RequestAuthenticationUpdateFields(current, desired)
+
+		Expect(current.Spec.GetSelector()).To(Equal(desired.Spec.GetSelector()))
+		Expect(current.Spec.GetJwtRules()).To(Equal(desired.Spec.GetJwtRules()))
+		Expect(current.Labels).To(Equal(desired.Labels))
+	})
+})
+
+var _ = Describe("AuthorizationPolicyUpdateFields", func() {
+	It("copies the selector, rules and labels from desired to current", func() {
+		current := &istioclientsecurityv1.AuthorizationPolicy{}
+		desired := &istioclientsecurityv1.AuthorizationPolicy{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels.AuthPolicyStandardLabels()},
+			Spec: istioapisecurityv1beta1.AuthorizationPolicy{
+				Selector: &istioapitypev1beta1.WorkloadSelector{MatchLabels: map[string]string{"app": "test"}},
+				Rules:    []*istioapisecurityv1beta1.Rule{{}},
+			},
+		}
+
+		reconciler.AuthorizationPolicyUpdateFields(current, desired)
+
+		Expect(current.Spec.GetSelector()).To(Equal(desired.Spec.GetSelector()))
+		Expect(current.Spec.GetRules()).To(Equal(desired.Spec.GetRules()))
+		Expect(current.Labels).To(Equal(desired.Labels))
+	})
+})

--- a/internal/reconciler/suite_test.go
+++ b/internal/reconciler/suite_test.go
@@ -1,0 +1,115 @@
+package reconciler_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	ztoperatorv1alpha1 "github.com/kartverket/ztoperator/api/v1alpha1"
+	"github.com/kartverket/ztoperator/pkg/config"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	istionetworkingv1 "istio.io/client-go/pkg/apis/networking/v1"
+	"istio.io/client-go/pkg/apis/networking/v1alpha3"
+	securityv1 "istio.io/client-go/pkg/apis/security/v1"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	testEnv   *envtest.Environment
+	cfg       *rest.Config
+	k8sClient client.Client
+)
+
+func TestReconciler(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Reconciler Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	var err error
+	err = ztoperatorv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = istionetworkingv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = v1alpha3.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = securityv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Load environment variables
+	err = config.Load()
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	// Retrieve the first found binary directory to allow running tests from IDEs
+	if getFirstFoundEnvTestBinaryDir() != "" {
+		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
+	}
+
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
+// ENVTEST-based tests depend on specific binaries, usually located in paths set by
+// controller-runtime. When running tests directly (e.g., via an IDE) without using
+// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
+//
+// This function streamlines the process by finding the required binaries, similar to
+// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
+// properly set up, run 'make setup-envtest' beforehand.
+func getFirstFoundEnvTestBinaryDir() string {
+	basePath := filepath.Join("..", "..", "bin", "k8s")
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		logf.Log.Error(err, "Failed to read directory", "path", basePath)
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+	return ""
+}

--- a/pkg/reconciliation/reconciler.go
+++ b/pkg/reconciliation/reconciler.go
@@ -2,12 +2,41 @@ package reconciliation
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
 	"github.com/kartverket/ztoperator/internal/state"
+	"github.com/kartverket/ztoperator/pkg/helperfunctions"
+	"github.com/kartverket/ztoperator/pkg/log"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const (
+	RequiresCreateAction ReconcileAction = iota
+	RequiresUpdateAction
+	RequiresDeleteAction
+	RequiresNoAction
+)
+
+type ReconcileAction int
+
+func (reconcileAction ReconcileAction) Action() string {
+	switch reconcileAction {
+	case RequiresCreateAction:
+		return "creation"
+	case RequiresUpdateAction:
+		return "update"
+	case RequiresDeleteAction:
+		return "deletion"
+	case RequiresNoAction:
+		return "no action"
+	}
+	panic("Unknown reconcile action")
+}
 
 type ControllerResource interface {
 	Reconcile(ctx context.Context, k8sClient client.Client, scheme *runtime.Scheme) (ctrl.Result, error)
@@ -37,4 +66,266 @@ func CountNonNilResources(rfs []ControllerResource) int {
 		}
 	}
 	return count
+}
+
+// ReconcileControllerResource reconciles a single Kubernetes resource towards its desired state while respecting
+// ownership: Ztoperator only mutates or deletes resources that are controlled by the AuthPolicy in scope. Resources
+// with a matching name that are not owned by the AuthPolicy are left untouched (when desired is nil) or cause an error
+// (when they would otherwise be created or updated).
+func ReconcileControllerResource[T client.Object](
+	ctx context.Context,
+	k8sClient client.Client,
+	scheme *runtime.Scheme,
+	scope *state.Scope,
+	resourceKind, resourceName string,
+	desired *T,
+	shouldUpdate func(current, desired T) bool,
+	updateFields func(current, desired T),
+) (ctrl.Result, error) {
+	rLog := log.GetLogger(ctx)
+
+	resourceType := reflect.TypeOf((*T)(nil)).Elem()
+	current, _ := reflect.New(resourceType.Elem()).Interface().(T)
+	current.SetNamespace(scope.AuthPolicy.Namespace)
+	current.SetName(resourceName)
+
+	currentExists := true
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(current), current); err != nil {
+		if apierrors.IsNotFound(err) {
+			currentExists = false
+		} else {
+			errorReason := fmt.Sprintf(
+				"Unable to get %s %s/%s.",
+				resourceKind,
+				current.GetNamespace(),
+				current.GetName(),
+			)
+			scope.ReplaceDescendant(current, &errorReason, nil, resourceKind, resourceName)
+			return ctrl.Result{}, err
+		}
+	}
+
+	currentIsOwnedByAuthPolicy := metav1.IsControlledBy(current, &scope.AuthPolicy)
+
+	desiredIsNil := desired == nil || reflect.ValueOf(*desired).IsNil()
+
+	rLog.Info(
+		fmt.Sprintf("Determining reconcile action for %s %s/%s", resourceKind, current.GetNamespace(), current.GetName()),
+	)
+	reconcileAction, err := DetermineReconcileAction[T](
+		current,
+		desired,
+		desiredIsNil,
+		shouldUpdate,
+		currentExists,
+		currentIsOwnedByAuthPolicy,
+	)
+	if err != nil {
+		errorReason := fmt.Sprintf(
+			"Failed to reconcile %s %s/%s: %s",
+			resourceKind,
+			current.GetNamespace(),
+			current.GetName(),
+			err,
+		)
+		scope.ReplaceDescendant(current, &errorReason, nil, resourceKind, resourceName)
+		return ctrl.Result{}, err
+	}
+
+	rLog.Info(
+		fmt.Sprintf("%s %s/%s needs %s", resourceKind, current.GetNamespace(), current.GetName(), reconcileAction.Action()),
+	)
+
+	switch *reconcileAction {
+	case RequiresDeleteAction:
+		return reconcileOnDelete[T](rLog, ctx, k8sClient, scope, current, resourceKind, resourceName)
+	case RequiresCreateAction:
+		return reconcileOnCreate[T](rLog, ctx, scheme, scope, k8sClient, *desired, resourceKind, resourceName)
+	case RequiresUpdateAction:
+		return reconcileOnUpdate[T](rLog, ctx, k8sClient, scope, *desired, current, updateFields, resourceKind, resourceName)
+	case RequiresNoAction:
+		rLog.Debug(
+			fmt.Sprintf("No action needed for %s %s/%s.", resourceKind, current.GetNamespace(), current.GetName()),
+		)
+		if !desiredIsNil {
+			successMessage := fmt.Sprintf(
+				"Successfully reconciled %s %s/%s.",
+				resourceKind,
+				current.GetNamespace(),
+				resourceName,
+			)
+			rLog.Info(successMessage)
+			scope.ReplaceDescendant(current, nil, &successMessage, resourceKind, resourceName)
+		}
+		return ctrl.Result{}, nil
+	}
+	return ctrl.Result{}, fmt.Errorf(
+		"encountered unknown reconcile action when reconciling %s %s/%s",
+		resourceKind,
+		current.GetNamespace(),
+		current.GetName(),
+	)
+}
+
+// DetermineReconcileAction decides which action is required to bring the current resource towards the desired state,
+// taking ownership into account:
+//   - When the desired resource is nil, it is deleted only if it exists and is owned by the AuthPolicy; otherwise no
+//     action is taken (an unowned resource with a matching name is ignored).
+//   - When the desired resource is not nil, a missing resource is created, an existing owned resource is updated when
+//     shouldUpdate reports a difference, and an existing resource that is not owned by the AuthPolicy results in an
+//     error so Ztoperator never overwrites resources it does not control.
+func DetermineReconcileAction[T client.Object](
+	current T,
+	desired *T,
+	isDesiredNil bool,
+	shouldUpdate func(current, desired T) bool,
+	currentExists bool,
+	currentIsOwnedByAuthPolicy bool,
+) (*ReconcileAction, error) {
+	if isDesiredNil {
+		if currentExists && currentIsOwnedByAuthPolicy {
+			return helperfunctions.Ptr(RequiresDeleteAction), nil
+		}
+		return helperfunctions.Ptr(RequiresNoAction), nil
+	}
+
+	if !currentExists {
+		return helperfunctions.Ptr(RequiresCreateAction), nil
+	}
+
+	if !currentIsOwnedByAuthPolicy {
+		return nil, fmt.Errorf(
+			"cannot update %s/%s as it is not owned by AuthPolicy",
+			current.GetNamespace(),
+			current.GetName(),
+		)
+	}
+
+	if shouldUpdate(current, *desired) {
+		return helperfunctions.Ptr(RequiresUpdateAction), nil
+	}
+
+	return helperfunctions.Ptr(RequiresNoAction), nil
+}
+
+func reconcileOnCreate[T client.Object](
+	rLog log.Logger,
+	ctx context.Context,
+	scheme *runtime.Scheme,
+	scope *state.Scope,
+	k8sClient client.Client,
+	desired T,
+	resourceKind, resourceName string,
+) (ctrl.Result, error) {
+	rLog.Debug(
+		fmt.Sprintf("%s %s/%s does not exist", resourceKind, desired.GetNamespace(), desired.GetName()),
+	)
+
+	if controllerRefErr := ctrl.SetControllerReference(&scope.AuthPolicy, desired, scheme); controllerRefErr != nil {
+		errorReason := fmt.Sprintf(
+			"Unable to set AuthPolicy ownerReference on %s %s/%s.",
+			resourceKind,
+			desired.GetNamespace(),
+			desired.GetName(),
+		)
+		scope.ReplaceDescendant(desired, &errorReason, nil, resourceKind, resourceName)
+		return ctrl.Result{}, controllerRefErr
+	}
+
+	rLog.Info(
+		fmt.Sprintf("Creating %s %s/%s", resourceKind, desired.GetNamespace(), desired.GetName()),
+	)
+	if createErr := k8sClient.Create(ctx, desired); createErr != nil {
+		errorReason := fmt.Sprintf(
+			"Unable to create %s %s/%s",
+			resourceKind,
+			desired.GetNamespace(),
+			desired.GetName(),
+		)
+		scope.ReplaceDescendant(desired, &errorReason, nil, resourceKind, resourceName)
+		return ctrl.Result{}, createErr
+	}
+
+	successMessage := fmt.Sprintf(
+		"Successfully created %s %s/%s.",
+		resourceKind,
+		desired.GetNamespace(),
+		desired.GetName(),
+	)
+	scope.ReplaceDescendant(desired, nil, &successMessage, resourceKind, resourceName)
+	return ctrl.Result{}, nil
+}
+
+func reconcileOnUpdate[T client.Object](
+	rLog log.Logger,
+	ctx context.Context,
+	k8sClient client.Client,
+	scope *state.Scope,
+	desired T,
+	current T,
+	updateFields func(current, desired T),
+	resourceKind, resourceName string,
+) (ctrl.Result, error) {
+	rLog.Debug(
+		fmt.Sprintf("Updating %s %s/%s with patch operation", resourceKind, desired.GetNamespace(), desired.GetName()),
+	)
+	before := current.DeepCopyObject().(client.Object)
+	updateFields(current, desired)
+
+	if patchErr := k8sClient.Patch(ctx, current, client.MergeFrom(before)); patchErr != nil {
+		errorReason := fmt.Sprintf(
+			"Unable to patch %s %s/%s",
+			resourceKind,
+			desired.GetNamespace(),
+			desired.GetName(),
+		)
+		scope.ReplaceDescendant(current, &errorReason, nil, resourceKind, resourceName)
+		return ctrl.Result{}, patchErr
+	}
+
+	successMessage := fmt.Sprintf(
+		"Successfully updated %s %s/%s.",
+		resourceKind,
+		desired.GetNamespace(),
+		desired.GetName(),
+	)
+	scope.ReplaceDescendant(current, nil, &successMessage, resourceKind, resourceName)
+	return ctrl.Result{}, nil
+}
+
+func reconcileOnDelete[T client.Object](
+	rLog log.Logger,
+	ctx context.Context,
+	k8sClient client.Client,
+	scope *state.Scope,
+	current T,
+	resourceKind, resourceName string,
+) (ctrl.Result, error) {
+	rLog.Info(
+		fmt.Sprintf(
+			"Desired %s %s/%s is nil and it is owned by AuthPolicy %s/%s. Will try to delete it.",
+			resourceKind,
+			current.GetNamespace(),
+			current.GetName(),
+			scope.AuthPolicy.Namespace,
+			scope.AuthPolicy.Name,
+		),
+	)
+
+	if deleteErr := k8sClient.Delete(ctx, current); deleteErr != nil {
+		deleteErrorMessage := fmt.Sprintf(
+			"Failed to delete %s %s/%s",
+			resourceKind,
+			current.GetNamespace(),
+			current.GetName(),
+		)
+		rLog.Error(deleteErr, deleteErrorMessage)
+		scope.ReplaceDescendant(current, &deleteErrorMessage, nil, resourceKind, resourceName)
+		return ctrl.Result{}, deleteErr
+	}
+
+	rLog.Debug(
+		fmt.Sprintf("Successfully deleted %s %s/%s", resourceKind, current.GetNamespace(), current.GetName()),
+	)
+	return ctrl.Result{}, nil
 }

--- a/pkg/reconciliation/reconciler_test.go
+++ b/pkg/reconciliation/reconciler_test.go
@@ -1,0 +1,161 @@
+package reconciliation_test
+
+import (
+	"testing"
+
+	"github.com/kartverket/ztoperator/pkg/reconciliation"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestReconciliation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Reconciliation Suite")
+}
+
+var _ = Describe("DetermineReconcileAction", func() {
+	// Build a current/desired pair of *corev1.ConfigMap to use across tests.
+	// The concrete type only matters insofar as T satisfies client.Object;
+	// ConfigMap is the simplest such type available here.
+	makeConfigMap := func(name, ns string) *corev1.ConfigMap {
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		}
+	}
+
+	// shouldUpdateAlways and shouldUpdateNever are stub predicates used to
+	// pin the should-update branch independently of object equality logic.
+	shouldUpdateAlways := func(_, _ *corev1.ConfigMap) bool { return true }
+	shouldUpdateNever := func(_, _ *corev1.ConfigMap) bool { return false }
+
+	Context("when isDesiredNil is true", func() {
+		It("returns RequiresDeleteAction when the resource exists and is owned by the AuthPolicy", func() {
+			action, err := reconciliation.DetermineReconcileAction[*corev1.ConfigMap](
+				makeConfigMap("foo", "ns"),
+				nil,
+				true,
+				shouldUpdateNever,
+				true,
+				true,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(action).NotTo(BeNil())
+			Expect(*action).To(Equal(reconciliation.RequiresDeleteAction))
+		})
+
+		It("returns RequiresNoAction when the resource exists but is NOT owned by the AuthPolicy", func() {
+			action, err := reconciliation.DetermineReconcileAction[*corev1.ConfigMap](
+				makeConfigMap("foo", "ns"),
+				nil,
+				true,
+				shouldUpdateNever,
+				true,
+				false,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(action).NotTo(BeNil())
+			Expect(*action).To(Equal(reconciliation.RequiresNoAction))
+		})
+
+		It("returns RequiresNoAction when the resource does not exist", func() {
+			action, err := reconciliation.DetermineReconcileAction[*corev1.ConfigMap](
+				makeConfigMap("foo", "ns"),
+				nil,
+				true,
+				shouldUpdateNever,
+				false,
+				false,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(action).NotTo(BeNil())
+			Expect(*action).To(Equal(reconciliation.RequiresNoAction))
+		})
+	})
+
+	Context("when isDesiredNil is false", func() {
+		desired := makeConfigMap("foo", "ns")
+
+		It("returns RequiresCreateAction when the resource does not exist", func() {
+			action, err := reconciliation.DetermineReconcileAction[*corev1.ConfigMap](
+				makeConfigMap("foo", "ns"),
+				&desired,
+				false,
+				shouldUpdateNever,
+				false,
+				false,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(action).NotTo(BeNil())
+			Expect(*action).To(Equal(reconciliation.RequiresCreateAction))
+		})
+
+		It("returns an error when the resource exists but is not owned by the AuthPolicy", func() {
+			action, err := reconciliation.DetermineReconcileAction[*corev1.ConfigMap](
+				makeConfigMap("foo", "ns"),
+				&desired,
+				false,
+				shouldUpdateNever,
+				true,
+				false,
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("cannot update ns/foo as it is not owned by AuthPolicy"))
+			Expect(action).To(BeNil())
+		})
+
+		It("returns RequiresUpdateAction when the resource exists, is owned, and shouldUpdate returns true", func() {
+			action, err := reconciliation.DetermineReconcileAction[*corev1.ConfigMap](
+				makeConfigMap("foo", "ns"),
+				&desired,
+				false,
+				shouldUpdateAlways,
+				true,
+				true,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(action).NotTo(BeNil())
+			Expect(*action).To(Equal(reconciliation.RequiresUpdateAction))
+		})
+
+		It("returns RequiresNoAction when the resource exists, is owned, and shouldUpdate returns false", func() {
+			action, err := reconciliation.DetermineReconcileAction[*corev1.ConfigMap](
+				makeConfigMap("foo", "ns"),
+				&desired,
+				false,
+				shouldUpdateNever,
+				true,
+				true,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(action).NotTo(BeNil())
+			Expect(*action).To(Equal(reconciliation.RequiresNoAction))
+		})
+
+		It("passes current and *desired to shouldUpdate verbatim", func() {
+			current := makeConfigMap("current-name", "ns")
+			desiredCM := makeConfigMap("desired-name", "ns")
+			desiredPtr := &desiredCM
+
+			var gotCurrent, gotDesired *corev1.ConfigMap
+			shouldUpdateSpy := func(c, d *corev1.ConfigMap) bool {
+				gotCurrent = c
+				gotDesired = d
+				return true
+			}
+
+			_, err := reconciliation.DetermineReconcileAction[*corev1.ConfigMap](
+				current,
+				desiredPtr,
+				false,
+				shouldUpdateSpy,
+				true, // currentExists
+				true, // currentIsOwnedByAuthPolicy
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gotCurrent).To(BeIdenticalTo(current))
+			Expect(gotDesired).To(BeIdenticalTo(desiredCM))
+		})
+	})
+})

--- a/test/chainsaw/authpolicy/owner_reference_desired_nil/authpolicy-ready-assert.yaml
+++ b/test/chainsaw/authpolicy/owner_reference_desired_nil/authpolicy-ready-assert.yaml
@@ -1,0 +1,13 @@
+# With autoLogin.enabled: false, desired state for the EnvoyFilter is nil. The pre-existing, unowned EnvoyFilter
+# is ignored rather than deleted, so this is NOT an error: the AuthPolicy is Ready.
+apiVersion: ztoperator.kartverket.no/v1alpha1
+kind: AuthPolicy
+metadata:
+  name: auth-policy
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
+status:
+  phase: Ready
+  ready: true
+  message: AuthPolicy ready.

--- a/test/chainsaw/authpolicy/owner_reference_desired_nil/authpolicy.yaml
+++ b/test/chainsaw/authpolicy/owner_reference_desired_nil/authpolicy.yaml
@@ -1,0 +1,18 @@
+apiVersion: ztoperator.kartverket.no/v1alpha1
+kind: AuthPolicy
+metadata:
+  name: auth-policy
+spec:
+  enabled: true
+  # autoLogin.enabled: false means desired state for EnvoyFilter (and Secret) is nil,
+  # so a pre-existing EnvoyFilter without an ownerReference must be left untouched.
+  autoLogin:
+    enabled: false
+    scopes:
+      - openid
+  allowedAudiences:
+    - value: entraid_server
+  wellKnownURI: http://mock-oauth2.auth:8080/entraid/.well-known/openid-configuration
+  selector:
+    matchLabels:
+      app: application

--- a/test/chainsaw/authpolicy/owner_reference_desired_nil/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/owner_reference_desired_nil/chainsaw-test.yaml
@@ -1,0 +1,29 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: owner-reference-desired-nil
+spec:
+  skip: false
+  concurrent: true
+  skipDelete: false
+  namespaceTemplate:
+    metadata:
+      labels:
+        istio-injection: enabled
+  steps:
+    - try:
+        # Pre-create an EnvoyFilter with the same name the operator generates for the AuthPolicy login filter
+        - apply:
+            file: foreign-envoy-filter.yaml
+        # Try create authpolicy with autoLogin.enabled: false
+        - create:
+            file: authpolicy.yaml
+        # Should succeed and become ready
+        - assert:
+            file: authpolicy-ready-assert.yaml
+        # The operator must have created the RequestAuthentication (autoLogin disabled, not the whole policy)
+        - assert:
+            file: request-authentication-assert.yaml
+        # The foreign EnvoyFilter (desired is nil when autoLogin disabled) must be left untouched
+        - assert:
+            file: foreign-envoy-filter.yaml

--- a/test/chainsaw/authpolicy/owner_reference_desired_nil/foreign-envoy-filter.yaml
+++ b/test/chainsaw/authpolicy/owner_reference_desired_nil/foreign-envoy-filter.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: auth-policy-login
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: foreign-filter
+

--- a/test/chainsaw/authpolicy/owner_reference_desired_nil/request-authentication-assert.yaml
+++ b/test/chainsaw/authpolicy/owner_reference_desired_nil/request-authentication-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: auth-policy
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
+spec:
+  jwtRules:
+    - audiences:
+        - entraid_server
+      forwardOriginalToken: true
+      issuer: http://mock-oauth2.auth:8080/entraid
+      jwksUri: http://mock-oauth2.auth:8080/entraid/jwks
+  selector:
+    matchLabels:
+      app: application
+

--- a/test/chainsaw/authpolicy/owner_reference_desired_update/authpolicy-failed-assert.yaml
+++ b/test/chainsaw/authpolicy/owner_reference_desired_update/authpolicy-failed-assert.yaml
@@ -1,0 +1,17 @@
+# The AuthPolicy cannot fully reconcile because the RequestAuthentication it wants to manage is owned by someone
+# else, so it must report a failed, not-ready status, and the descendant condition for that RequestAuthentication
+# must spell out the ownership conflict.
+apiVersion: ztoperator.kartverket.no/v1alpha1
+kind: AuthPolicy
+metadata:
+  name: auth-policy
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
+status:
+  phase: Failed
+  ready: false
+  message: AuthPolicy failed.
+  (length(conditions[?type == 'RequestAuthentication-auth-policy'])): 1
+  (length(conditions[?type == 'RequestAuthentication-auth-policy' && status == 'False' && reason == 'Error'])): 1
+  (length(conditions[?type == 'RequestAuthentication-auth-policy' && contains(message, 'not owned by AuthPolicy')])): 1

--- a/test/chainsaw/authpolicy/owner_reference_desired_update/authpolicy.yaml
+++ b/test/chainsaw/authpolicy/owner_reference_desired_update/authpolicy.yaml
@@ -1,0 +1,12 @@
+apiVersion: ztoperator.kartverket.no/v1alpha1
+kind: AuthPolicy
+metadata:
+  name: auth-policy
+spec:
+  enabled: true
+  allowedAudiences:
+    - value: entraid_server
+  wellKnownURI: http://mock-oauth2.auth:8080/entraid/.well-known/openid-configuration
+  selector:
+    matchLabels:
+      app: application

--- a/test/chainsaw/authpolicy/owner_reference_desired_update/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/owner_reference_desired_update/chainsaw-test.yaml
@@ -1,0 +1,29 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: owner-reference-desired-update
+spec:
+  skip: false
+  concurrent: true
+  skipDelete: false
+  namespaceTemplate:
+    metadata:
+      labels:
+        istio-injection: enabled
+  steps:
+    - try:
+        # Pre-create a RequestAuthentication with the same name the operator generates for the AuthPolicy
+        - apply:
+            file: foreign-request-authentication.yaml
+        # Try create authpolicy
+        - create:
+            file: authpolicy.yaml
+        # The ownership conflict on the RequestAuthentication must surface as a reconciliation failure.
+        - assert:
+            file: authpolicy-failed-assert.yaml
+        # Other resources are still created
+        - assert:
+            file: require-auth-authorizationpolicy-assert.yaml
+        # The foreign RequestAuthentication must be left as it was
+        - assert:
+            file: foreign-request-authentication.yaml

--- a/test/chainsaw/authpolicy/owner_reference_desired_update/foreign-request-authentication-assert.yaml
+++ b/test/chainsaw/authpolicy/owner_reference_desired_update/foreign-request-authentication-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: auth-policy
+spec:
+  selector:
+    matchLabels:
+      app: foreign-app
+  jwtRules:
+    - issuer: https://foreign-issuer.example.com
+      jwksUri: https://foreign-issuer.example.com/.well-known/jwks.json

--- a/test/chainsaw/authpolicy/owner_reference_desired_update/foreign-request-authentication.yaml
+++ b/test/chainsaw/authpolicy/owner_reference_desired_update/foreign-request-authentication.yaml
@@ -1,0 +1,11 @@
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: auth-policy
+spec:
+  selector:
+    matchLabels:
+      app: foreign-app
+  jwtRules:
+    - issuer: https://foreign-issuer.example.com
+      jwksUri: https://foreign-issuer.example.com/.well-known/jwks.json

--- a/test/chainsaw/authpolicy/owner_reference_desired_update/require-auth-authorizationpolicy-assert.yaml
+++ b/test/chainsaw/authpolicy/owner_reference_desired_update/require-auth-authorizationpolicy-assert.yaml
@@ -1,0 +1,13 @@
+# Resources that do not collide with a foreign resource are still created and owned by Ztoperator. The presence of
+# this AuthorizationPolicy proves reconciliation progressed past resolution and reached the resource step.
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: auth-policy-require-auth
+  labels:
+    ztoperator.kartverket.no/controller: authpolicy
+    app.kubernetes.io/managed-by: ztoperator
+spec:
+  selector:
+    matchLabels:
+      app: application


### PR DESCRIPTION
## Checklist
- [x] Commits follow best practice git conventions
- [x] Introduced dependencies are reviewed
- [x] (feel free to review - pretty similar to accesserator, except also shouldUpdate-logic + chainsaw) Test coverage is adequate
- [x] (not relevant) New features are documented on `skip.kartverket.no`
- [x] (not relevant) Changes to CRD are documented on `skip.kartverket.no`
- [x] (not relevant) Changes are supported by the `skip-ztoperator` copilot skill
- [x] (not relevant) `setup-skip-action` and `test-authpolicy-action` are compatible with changes
- [x] Code in this PR was written using AI assistance

## Description

### Most importantly
[Make reconciliation respect owner reference for deletes/updates](https://github.com/kartverket/ztoperator/commit/da3ef89a81b09e84dc7efbb858681cba37a4e874) 

If there already exists resources that are not owned by the Ztoperator AuthPolicy resource, we should:

- If our desired is nil, but the resource exists -> no-op
- Otherwise, throw error because we cannot update or create it

Ztoperator should never modify resources without owner reference. Worst case, this can cause situations like us deleting non-owned EnvoyFilter resources etc.

I move reconcile logic regarding create/update/delete etc. from the internal package to the pkg package, same as for Accesserator.

I also introduce similar test coverage for reconciliation as has previously been done for Accesserator. I felt testing the shouldupdate functionality was more important than keeping the methods private.

### Other stuff
Some lint-configuration after updating golangci_lint