### PR TITLE
Set AutoLoginConfig.EnvoySecretName when autologin is disabled

### DIFF
--- a/internal/reconciler/resources_test.go
+++ b/internal/reconciler/resources_test.go
@@ -7,6 +7,7 @@ import (
 	ztoperatorv1alpha1 "github.com/kartverket/ztoperator/api/v1alpha1"
 	"github.com/kartverket/ztoperator/internal/names"
 	"github.com/kartverket/ztoperator/internal/reconciler"
+	"github.com/kartverket/ztoperator/internal/resolver"
 	"github.com/kartverket/ztoperator/internal/state"
 	"github.com/kartverket/ztoperator/pkg/helperfunctions"
 	"github.com/kartverket/ztoperator/pkg/labels"
@@ -82,6 +83,42 @@ var _ = Describe("ControllerResources", func() {
 			),
 		)
 	})
+
+	DescribeTable(
+		"Secret resource produced by ControllerResources has a non-empty name when autologin is",
+		func(autoLogin *ztoperatorv1alpha1.AutoLogin) {
+			authPolicy := &ztoperatorv1alpha1.AuthPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      authPolicyName,
+					Namespace: "some-namespace",
+				},
+				Spec: ztoperatorv1alpha1.AuthPolicySpec{
+					AutoLogin: autoLogin,
+				},
+			}
+			scope := &state.Scope{
+				AuthPolicy: *authPolicy,
+				AutoLoginConfig: resolver.ResolveAutoLoginConfig(
+					authPolicy,
+					state.IdentityProviderUris{},
+				),
+			}
+
+			resources := reconciler.ControllerResources(scope)
+
+			var secretName string
+			for _, r := range resources {
+				if r.GetResourceKind() == "Secret" {
+					secretName = r.GetResourceName()
+					break
+				}
+			}
+			Expect(secretName).NotTo(BeEmpty(), "Secret resource name must not be empty")
+			Expect(secretName).To(Equal(names.EnvoySecret(authPolicyName)))
+		},
+		Entry("explicitly disabled", &ztoperatorv1alpha1.AutoLogin{Enabled: false}),
+		Entry("nil", nil),
+	)
 })
 
 var _ = Describe("auto-login Secret reconciliation", func() {

--- a/internal/resolver/autologin_config_resolver.go
+++ b/internal/resolver/autologin_config_resolver.go
@@ -12,13 +12,14 @@ func ResolveAutoLoginConfig(
 	authPolicy *ztoperatorv1alpha1.AuthPolicy,
 	identityProviderUris state.IdentityProviderUris,
 ) state.AutoLoginConfig {
+	envoySecretName := names.EnvoySecret(authPolicy.Name)
+
 	if authPolicy.Spec.AutoLogin == nil || !authPolicy.Spec.AutoLogin.Enabled {
 		return state.AutoLoginConfig{
-			Enabled: false,
+			Enabled:         false,
+			EnvoySecretName: envoySecretName,
 		}
 	}
-
-	envoySecretName := names.EnvoySecret(authPolicy.Name)
 
 	autoLoginConfig := state.AutoLoginConfig{
 		Enabled:               authPolicy.Spec.AutoLogin.Enabled,

--- a/internal/resolver/autologin_config_resolver_test.go
+++ b/internal/resolver/autologin_config_resolver_test.go
@@ -22,7 +22,12 @@ func TestResolveAutoLoginConfig_WithAutoLoginDisabled_ReturnsDisabledConfig(t *t
 
 	// 3. Assert
 	assert.False(t, result.Enabled, "AutoLogin should be disabled")
-	assert.Empty(t, result.EnvoySecretName, "EnvoySecretName should be empty when disabled")
+	assert.Equal(
+		t,
+		"test-policy-envoy-secret",
+		result.EnvoySecretName,
+		"EnvoySecretName should always be set, even when auto-login is disabled",
+	)
 	assert.Empty(t, result.LuaScriptConfig.LuaScript, "LuaScript should be empty when disabled")
 }
 
@@ -36,6 +41,15 @@ func TestResolveAutoLoginConfig_WithAutoLoginNil_ReturnsDisabledConfig(t *testin
 
 	// 3. Assert
 	assert.False(t, result.Enabled, "AutoLogin should be disabled when nil")
+	// Regression: same as the disabled case — EnvoySecretName must be populated even when AutoLogin
+	// is nil so that the Secret reconciler does not operate on an empty resource name.
+	assert.Equal(
+		t,
+		"test-policy-envoy-secret",
+		result.EnvoySecretName,
+		"EnvoySecretName should always be set, even when AutoLogin is nil",
+	)
+	assert.Empty(t, result.LuaScriptConfig.LuaScript, "LuaScript should be empty when AutoLogin is nil")
 }
 
 func TestResolveAutoLoginConfig_WithBasicAutoLogin_ReturnsConfigWithDefaults(t *testing.T) {


### PR DESCRIPTION
## Checklist
- [x] Commits follow best practice git conventions
- [x] Introduced dependencies are reviewed
- [x] Test coverage is adequate
- [x] New features are documented on `skip.kartverket.no`
- [x] Changes to CRD are documented on `skip.kartverket.no`
- [x] Changes are supported by the `skip-ztoperator` copilot skill
- [x] `setup-skip-action` and `test-authpolicy-action` are compatible with changes
- [x] Code in this PR was written using AI assistance

## Description
Even if autologin is disabled, we need the name of the envoy secret to determine which resource to delete when desired=nil. This bug causes secret to remain when autologin is toggled from true to false.
