### PR TITLE
test(controller): add happy-path reconcile test for AuthPolicy without auto-login

### DIFF
--- a/internal/controller/authpolicy_controller_reconcile_test.go
+++ b/internal/controller/authpolicy_controller_reconcile_test.go
@@ -68,6 +68,7 @@ func TestAuthPolicyReconcileHappyPathWithoutAutoLogin(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       apName,
 			Namespace:  namespace,
+			UID:        types.UID("test-uid-12345"),
 			Generation: 1,
 		},
 		Spec: ztoperatorv1alpha1.AuthPolicySpec{

--- a/internal/controller/authpolicy_controller_reconcile_test.go
+++ b/internal/controller/authpolicy_controller_reconcile_test.go
@@ -97,7 +97,7 @@ func TestAuthPolicyReconcileHappyPathWithoutAutoLogin(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Zero(t, result.RequeueAfter)
-	assert.False(t, result.Requeue)
+	assert.Equal(t, ctrl.Result{}, result)
 	ra := &securityv1.RequestAuthentication{}
 	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: apName, Namespace: namespace}, ra))
 	require.Len(t, ra.Spec.GetJwtRules(), 1)

--- a/internal/controller/authpolicy_controller_reconcile_test.go
+++ b/internal/controller/authpolicy_controller_reconcile_test.go
@@ -1,0 +1,137 @@
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	ztoperatorv1alpha1 "github.com/kartverket/ztoperator/api/v1alpha1"
+	"github.com/kartverket/ztoperator/internal/controller"
+	"github.com/kartverket/ztoperator/internal/names"
+	"github.com/kartverket/ztoperator/pkg/helperfunctions"
+	"github.com/kartverket/ztoperator/pkg/log"
+	"github.com/kartverket/ztoperator/pkg/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1alpha4 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	securityv1 "istio.io/client-go/pkg/apis/security/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sevents "k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type fakeDiscoveryDocumentResolver struct {
+	document *rest.DiscoveryDocument
+	err      error
+}
+
+func (f *fakeDiscoveryDocumentResolver) GetOAuthDiscoveryDocument(
+	_ string,
+	_ log.Logger,
+) (*rest.DiscoveryDocument, error) {
+	return f.document, f.err
+}
+
+func newBasicDiscoveryResolver() *fakeDiscoveryDocumentResolver {
+	return &fakeDiscoveryDocumentResolver{
+		document: &rest.DiscoveryDocument{
+			Issuer:        helperfunctions.Ptr("https://idp.example.com"),
+			JwksURI:       helperfunctions.Ptr("https://idp.example.com/jwks"),
+			TokenEndpoint: helperfunctions.Ptr("https://idp.example.com/token"),
+		},
+	}
+}
+
+func TestAuthPolicyReconcileHappyPathWithoutAutoLogin(t *testing.T) {
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, ztoperatorv1alpha1.AddToScheme(scheme))
+	require.NoError(t, v1alpha4.AddToScheme(scheme))
+	require.NoError(t, securityv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	const (
+		namespace = "test-controller"
+		apName    = "my-app"
+	)
+
+	authPolicy := &ztoperatorv1alpha1.AuthPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AuthPolicy",
+			APIVersion: "ztoperator.kartverket.no/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       apName,
+			Namespace:  namespace,
+			Generation: 1,
+		},
+		Spec: ztoperatorv1alpha1.AuthPolicySpec{
+			Enabled:      true,
+			WellKnownURI: "https://idp.example.com/.well-known/openid-configuration",
+			Selector: ztoperatorv1alpha1.WorkloadSelector{
+				MatchLabels: map[string]string{"app": apName},
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(authPolicy).
+		WithStatusSubresource(authPolicy).
+		Build()
+
+	reconciler := &controller.AuthPolicyReconciler{
+		Client:                    k8sClient,
+		Scheme:                    scheme,
+		Recorder:                  k8sevents.NewFakeRecorder(100),
+		DiscoveryDocumentResolver: newBasicDiscoveryResolver(),
+	}
+
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: apName, Namespace: namespace},
+	})
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+
+	ra := &securityv1.RequestAuthentication{}
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: apName, Namespace: namespace}, ra))
+	require.Len(t, ra.Spec.GetJwtRules(), 1)
+	assert.Equal(t, "https://idp.example.com", ra.Spec.GetJwtRules()[0].GetIssuer())
+	assert.Equal(t, "https://idp.example.com/jwks", ra.Spec.GetJwtRules()[0].GetJwksUri())
+	assert.Equal(t, map[string]string{"app": apName}, ra.Spec.GetSelector().GetMatchLabels())
+	assert.True(t, metav1.IsControlledBy(ra, authPolicy))
+
+	requirePolicy := &securityv1.AuthorizationPolicy{}
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{
+		Name:      names.RequirePolicy(apName),
+		Namespace: namespace,
+	}, requirePolicy))
+	assert.True(t, metav1.IsControlledBy(requirePolicy, authPolicy))
+
+	ef := &v1alpha4.EnvoyFilter{}
+	efErr := k8sClient.Get(ctx, types.NamespacedName{Name: names.EnvoyFilter(apName), Namespace: namespace}, ef)
+	assert.True(t, apierrors.IsNotFound(efErr))
+
+	envoySecret := &corev1.Secret{}
+	secretErr := k8sClient.Get(ctx, types.NamespacedName{Name: names.EnvoySecret(apName), Namespace: namespace}, envoySecret)
+	assert.True(t, apierrors.IsNotFound(secretErr))
+
+	denyPolicy := &securityv1.AuthorizationPolicy{}
+	denyErr := k8sClient.Get(ctx, types.NamespacedName{Name: names.DenyPolicy(apName), Namespace: namespace}, denyPolicy)
+	assert.True(t, apierrors.IsNotFound(denyErr))
+
+	ignorePolicy := &securityv1.AuthorizationPolicy{}
+	ignoreErr := k8sClient.Get(ctx, types.NamespacedName{Name: names.IgnorePolicy(apName), Namespace: namespace}, ignorePolicy)
+	assert.True(t, apierrors.IsNotFound(ignoreErr))
+
+	updatedPolicy := &ztoperatorv1alpha1.AuthPolicy{}
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: apName, Namespace: namespace}, updatedPolicy))
+	assert.Equal(t, ztoperatorv1alpha1.PhaseReady, updatedPolicy.Status.Phase)
+	assert.True(t, updatedPolicy.Status.Ready)
+	assert.Equal(t, int64(1), updatedPolicy.Status.ObservedGeneration)
+}

--- a/internal/controller/authpolicy_controller_reconcile_test.go
+++ b/internal/controller/authpolicy_controller_reconcile_test.go
@@ -97,7 +97,7 @@ func TestAuthPolicyReconcileHappyPathWithoutAutoLogin(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Zero(t, result.RequeueAfter)
-
+	assert.False(t, result.Requeue)
 	ra := &securityv1.RequestAuthentication{}
 	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: apName, Namespace: namespace}, ra))
 	require.Len(t, ra.Spec.GetJwtRules(), 1)

--- a/internal/controller/authpolicy_controller_reconcile_test.go
+++ b/internal/controller/authpolicy_controller_reconcile_test.go
@@ -2,7 +2,6 @@ package controller_test
 
 import (
 	"context"
-	"testing"
 
 	ztoperatorv1alpha1 "github.com/kartverket/ztoperator/api/v1alpha1"
 	"github.com/kartverket/ztoperator/internal/controller"
@@ -10,8 +9,8 @@ import (
 	"github.com/kartverket/ztoperator/pkg/helperfunctions"
 	"github.com/kartverket/ztoperator/pkg/log"
 	"github.com/kartverket/ztoperator/pkg/rest"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	v1alpha4 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	securityv1 "istio.io/client-go/pkg/apis/security/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -21,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	k8sevents "k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -46,93 +46,108 @@ func newBasicDiscoveryResolver() *fakeDiscoveryDocumentResolver {
 	}
 }
 
-func TestAuthPolicyReconcileHappyPathWithoutAutoLogin(t *testing.T) {
-	ctx := context.Background()
-
-	scheme := runtime.NewScheme()
-	require.NoError(t, ztoperatorv1alpha1.AddToScheme(scheme))
-	require.NoError(t, v1alpha4.AddToScheme(scheme))
-	require.NoError(t, securityv1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+var _ = Describe("AuthPolicy Controller Reconcile", func() {
+	var (
+		testCtx    context.Context
+		testScheme *runtime.Scheme
+		fakeClient client.Client
+		reconciler *controller.AuthPolicyReconciler
+	)
 
 	const (
 		namespace = "test-controller"
-		apName    = "my-app"
+		appName   = "my-app"
 	)
 
-	authPolicy := &ztoperatorv1alpha1.AuthPolicy{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "AuthPolicy",
-			APIVersion: "ztoperator.kartverket.no/v1alpha1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       apName,
-			Namespace:  namespace,
-			UID:        types.UID("test-uid-12345"),
-			Generation: 1,
-		},
-		Spec: ztoperatorv1alpha1.AuthPolicySpec{
-			Enabled:      true,
-			WellKnownURI: "https://idp.example.com/.well-known/openid-configuration",
-			Selector: ztoperatorv1alpha1.WorkloadSelector{
-				MatchLabels: map[string]string{"app": apName},
+	BeforeEach(func() {
+		testCtx = context.Background()
+
+		testScheme = runtime.NewScheme()
+		Expect(ztoperatorv1alpha1.AddToScheme(testScheme)).To(Succeed())
+		Expect(v1alpha4.AddToScheme(testScheme)).To(Succeed())
+		Expect(securityv1.AddToScheme(testScheme)).To(Succeed())
+		Expect(corev1.AddToScheme(testScheme)).To(Succeed())
+
+		authPolicy := &ztoperatorv1alpha1.AuthPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       appName,
+				Namespace:  namespace,
+				Generation: 1,
 			},
-		},
-	}
+			Spec: ztoperatorv1alpha1.AuthPolicySpec{
+				Enabled:      true,
+				WellKnownURI: "https://idp.example.com/.well-known/openid-configuration",
+				Selector: ztoperatorv1alpha1.WorkloadSelector{
+					MatchLabels: map[string]string{"app": appName},
+				},
+			},
+		}
 
-	k8sClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(authPolicy).
-		WithStatusSubresource(authPolicy).
-		Build()
+		fakeClient = fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithObjects(authPolicy).
+			WithStatusSubresource(authPolicy).
+			Build()
 
-	reconciler := &controller.AuthPolicyReconciler{
-		Client:                    k8sClient,
-		Scheme:                    scheme,
-		Recorder:                  k8sevents.NewFakeRecorder(100),
-		DiscoveryDocumentResolver: newBasicDiscoveryResolver(),
-	}
-
-	result, err := reconciler.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: apName, Namespace: namespace},
+		reconciler = &controller.AuthPolicyReconciler{
+			Client:                    fakeClient,
+			Scheme:                    testScheme,
+			Recorder:                  k8sevents.NewFakeRecorder(100),
+			DiscoveryDocumentResolver: newBasicDiscoveryResolver(),
+		}
 	})
-	require.NoError(t, err)
-	assert.Zero(t, result.RequeueAfter)
-	assert.Equal(t, ctrl.Result{}, result)
-	ra := &securityv1.RequestAuthentication{}
-	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: apName, Namespace: namespace}, ra))
-	require.Len(t, ra.Spec.GetJwtRules(), 1)
-	assert.Equal(t, "https://idp.example.com", ra.Spec.GetJwtRules()[0].GetIssuer())
-	assert.Equal(t, "https://idp.example.com/jwks", ra.Spec.GetJwtRules()[0].GetJwksUri())
-	assert.Equal(t, map[string]string{"app": apName}, ra.Spec.GetSelector().GetMatchLabels())
-	assert.True(t, metav1.IsControlledBy(ra, authPolicy))
 
-	requirePolicy := &securityv1.AuthorizationPolicy{}
-	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{
-		Name:      names.RequirePolicy(apName),
-		Namespace: namespace,
-	}, requirePolicy))
-	assert.True(t, metav1.IsControlledBy(requirePolicy, authPolicy))
+	Context("a simple enabled AuthPolicy without auto-login", func() {
+		It("creates auth resources, skips auto-login resources, and reports Ready status", func() {
+			result, err := reconciler.Reconcile(testCtx, ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
 
-	ef := &v1alpha4.EnvoyFilter{}
-	efErr := k8sClient.Get(ctx, types.NamespacedName{Name: names.EnvoyFilter(apName), Namespace: namespace}, ef)
-	assert.True(t, apierrors.IsNotFound(efErr))
+			ra := &securityv1.RequestAuthentication{}
+			Expect(fakeClient.Get(testCtx, types.NamespacedName{Name: appName, Namespace: namespace}, ra)).To(Succeed())
+			Expect(ra.Spec.GetJwtRules()).To(HaveLen(1))
+			Expect(ra.Spec.GetJwtRules()[0].GetIssuer()).To(Equal("https://idp.example.com"))
+			Expect(ra.Spec.GetJwtRules()[0].GetJwksUri()).To(Equal("https://idp.example.com/jwks"))
+			Expect(ra.Spec.GetSelector().GetMatchLabels()).To(Equal(map[string]string{"app": appName}))
 
-	envoySecret := &corev1.Secret{}
-	secretErr := k8sClient.Get(ctx, types.NamespacedName{Name: names.EnvoySecret(apName), Namespace: namespace}, envoySecret)
-	assert.True(t, apierrors.IsNotFound(secretErr))
+			owner := &ztoperatorv1alpha1.AuthPolicy{}
+			Expect(fakeClient.Get(testCtx, types.NamespacedName{Name: appName, Namespace: namespace}, owner)).To(Succeed())
+			Expect(metav1.IsControlledBy(ra, owner)).To(BeTrue())
 
-	denyPolicy := &securityv1.AuthorizationPolicy{}
-	denyErr := k8sClient.Get(ctx, types.NamespacedName{Name: names.DenyPolicy(apName), Namespace: namespace}, denyPolicy)
-	assert.True(t, apierrors.IsNotFound(denyErr))
+			requirePolicy := &securityv1.AuthorizationPolicy{}
+			Expect(fakeClient.Get(testCtx, types.NamespacedName{
+				Name:      names.RequirePolicy(appName),
+				Namespace: namespace,
+			}, requirePolicy)).To(Succeed())
+			Expect(metav1.IsControlledBy(requirePolicy, owner)).To(BeTrue())
 
-	ignorePolicy := &securityv1.AuthorizationPolicy{}
-	ignoreErr := k8sClient.Get(ctx, types.NamespacedName{Name: names.IgnorePolicy(apName), Namespace: namespace}, ignorePolicy)
-	assert.True(t, apierrors.IsNotFound(ignoreErr))
+			ef := &v1alpha4.EnvoyFilter{}
+			efErr := fakeClient.Get(testCtx, types.NamespacedName{Name: names.EnvoyFilter(appName), Namespace: namespace}, ef)
+			Expect(apierrors.IsNotFound(efErr)).To(BeTrue())
 
-	updatedPolicy := &ztoperatorv1alpha1.AuthPolicy{}
-	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: apName, Namespace: namespace}, updatedPolicy))
-	assert.Equal(t, ztoperatorv1alpha1.PhaseReady, updatedPolicy.Status.Phase)
-	assert.True(t, updatedPolicy.Status.Ready)
-	assert.Equal(t, int64(1), updatedPolicy.Status.ObservedGeneration)
-}
+			envoySecret := &corev1.Secret{}
+			secretErr := fakeClient.Get(
+				testCtx,
+				types.NamespacedName{Name: names.EnvoySecret(appName), Namespace: namespace},
+				envoySecret,
+			)
+			Expect(apierrors.IsNotFound(secretErr)).To(BeTrue())
+
+			denyPolicy := &securityv1.AuthorizationPolicy{}
+			denyErr := fakeClient.Get(testCtx, types.NamespacedName{Name: names.DenyPolicy(appName), Namespace: namespace}, denyPolicy)
+			Expect(apierrors.IsNotFound(denyErr)).To(BeTrue())
+
+			ignorePolicy := &securityv1.AuthorizationPolicy{}
+			ignoreErr := fakeClient.Get(testCtx, types.NamespacedName{Name: names.IgnorePolicy(appName), Namespace: namespace}, ignorePolicy)
+			Expect(apierrors.IsNotFound(ignoreErr)).To(BeTrue())
+
+			updatedPolicy := &ztoperatorv1alpha1.AuthPolicy{}
+			Expect(fakeClient.Get(testCtx, types.NamespacedName{Name: appName, Namespace: namespace}, updatedPolicy)).To(Succeed())
+			Expect(updatedPolicy.Status.Phase).To(Equal(ztoperatorv1alpha1.PhaseReady))
+			Expect(updatedPolicy.Status.Ready).To(BeTrue())
+			Expect(updatedPolicy.Status.ObservedGeneration).To(Equal(int64(1)))
+		})
+	})
+})


### PR DESCRIPTION

## Checklist
- [x] Commits follow best practice git conventions
- [ ] Introduced dependencies are reviewed
- [ ] Test coverage is adequate
- [ ] New features are documented on `skip.kartverket.no`
- [ ] Changes to CRD are documented on `skip.kartverket.no`
- [ ] Changes are supported by the `skip-ztoperator` copilot skill
- [x] `setup-skip-action` and `test-authpolicy-action` are compatible with changes
- [x] Code in this PR was written using AI assistance

## Description
### What

Adds a new integration test for the `AuthPolicyReconciler.Reconcile()` method,
covering the most common scenario: a simple enabled AuthPolicy without auto-login.

### Why

The controller layer had no dedicated reconcile tests. This test establishes
a baseline and makes it easier to catch regressions when changing reconcile logic.

### What is tested

- `RequestAuthentication` is created with the correct issuer and workload selector
- `AuthorizationPolicy` (require) is created, enforcing authentication by default
- `EnvoyFilter` and envoy `Secret` are NOT created when auto-login is disabled
- `deny` and `ignore` policies are NOT created when no rules are configured
- `AuthPolicy` status is set to `Ready` with the correct `observedGeneration`

### Notes

Uses a fake Kubernetes client and a stubbed OIDC discovery resolver to keep
the test fast and free from external dependencies (no Istio CRDs or network calls required).