### PR TITLE
Explicitly set SameSite on cookies set by Envoy

### DIFF
--- a/pkg/resourcegenerators/envoyfilter/configpatch/configpatch_test.go
+++ b/pkg/resourcegenerators/envoyfilter/configpatch/configpatch_test.go
@@ -126,6 +126,31 @@ func TestGetOAuthSidecarConfigPatch_PassThroughAndDenyRedirectMatchers(t *testin
 	assert.Equal(t, luascript.DenyRedirectHeaderName, denyHeader["name"])
 }
 
+func TestGetOAuthSidecarConfigPatch_CookieConfigs_SameSiteLax(t *testing.T) {
+	scope := defaultScope()
+
+	result := configpatch.GetOAuthSidecarConfigPatchValue(scope)
+
+	inner := oauthInnerConfig(t, result)
+	cookieConfigs, ok := inner["cookie_configs"].(map[string]interface{})
+	require.True(t, ok, "cookie_configs must be present")
+
+	expectedCookies := []string{
+		"bearer_token_cookie_config",
+		"oauth_hmac_cookie_config",
+		"oauth_expires_cookie_config",
+		"id_token_cookie_config",
+		"refresh_token_cookie_config",
+		"oauth_nonce_cookie_config",
+		"code_verifier_cookie_config",
+	}
+	for _, key := range expectedCookies {
+		cfg, present := cookieConfigs[key].(map[string]interface{})
+		require.Truef(t, present, "%s must be present in cookie_configs", key)
+		assert.Equalf(t, "LAX", cfg["same_site"], "%s.same_site must be LAX", key)
+	}
+}
+
 func oauthInnerConfig(t *testing.T, patch map[string]interface{}) map[string]interface{} {
 	t.Helper()
 	typed, ok := patch["typed_config"].(map[string]interface{})

--- a/pkg/resourcegenerators/envoyfilter/configpatch/oauth_sidecar_config_patch.go
+++ b/pkg/resourcegenerators/envoyfilter/configpatch/oauth_sidecar_config_patch.go
@@ -103,6 +103,15 @@ func GetOAuthSidecarConfigPatchValue(
 			},
 		},
 		"auth_scopes": authScopesInterface,
+		"cookie_configs": map[string]interface{}{
+			"bearer_token_cookie_config":  map[string]interface{}{"same_site": "LAX"},
+			"oauth_hmac_cookie_config":    map[string]interface{}{"same_site": "LAX"},
+			"oauth_expires_cookie_config": map[string]interface{}{"same_site": "LAX"},
+			"id_token_cookie_config":      map[string]interface{}{"same_site": "LAX"},
+			"refresh_token_cookie_config": map[string]interface{}{"same_site": "LAX"},
+			"oauth_nonce_cookie_config":   map[string]interface{}{"same_site": "LAX"},
+			"code_verifier_cookie_config": map[string]interface{}{"same_site": "LAX"},
+		},
 	}
 
 	if scope.AuthPolicy.Spec.AcceptedResources != nil && len(*scope.AuthPolicy.Spec.AcceptedResources) > 0 {

--- a/test/chainsaw/authpolicy/auto_login_cookie_samesite/authpolicy.yaml
+++ b/test/chainsaw/authpolicy/auto_login_cookie_samesite/authpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: ztoperator.kartverket.no/v1alpha1
+kind: AuthPolicy
+metadata:
+  name: auth-policy
+spec:
+  enabled: true
+  oAuthCredentials:
+    clientIDKey: CLIENT_ID
+    clientSecretKey: CLIENT_SECRET
+    secretRef: oauth-secret
+  autoLogin:
+    enabled: true
+    logoutPath: /logout
+    redirectPath: /oauth2/callback
+    scopes:
+      - openid
+  wellKnownURI: http://mock-oauth2.auth:8080/entraid/.well-known/openid-configuration
+  selector:
+    matchLabels:
+      app: application
+

--- a/test/chainsaw/authpolicy/auto_login_cookie_samesite/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/auto_login_cookie_samesite/chainsaw-test.yaml
@@ -1,0 +1,30 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: auto-login-cookie-samesite
+spec:
+  skip: false
+  concurrent: true
+  skipDelete: false
+  namespaceTemplate:
+    metadata:
+      labels:
+        istio-injection: enabled
+  steps:
+    - try:
+        - create:
+            file: ../../../resources/skiperator/application-with-istio-mount.yaml
+        - apply:
+            file: ../../../resources/ingress/wildcard-ingress.yaml
+        - create:
+            file: ../../../resources/secret/oauth-secret.yaml
+        - create:
+            file: authpolicy.yaml
+        - script:
+            content: sleep 14
+        - script:
+            content: |
+              hurl --error-format long \
+              --insecure --test tests.hurl \
+              --variable entraid_refresh_token="$(../../../../venv/bin/python ./../../../../scripts/get-mock-oauth2-token.py --issuer entraid --code entraid_client --token_name refresh_token)"
+

--- a/test/chainsaw/authpolicy/auto_login_cookie_samesite/tests.hurl
+++ b/test/chainsaw/authpolicy/auto_login_cookie_samesite/tests.hurl
@@ -1,0 +1,31 @@
+# --- Initial unauthenticated request should trigger the OAuth Authorization Code
+# --- Flow. Envoy responds with 302 -> IdP authorize endpoint and sets the two
+# --- "flow" cookies (OauthNonce for CSRF/state, CodeVerifier for PKCE) that the
+# --- callback handler will later validate. Both must be SameSite=Lax so they
+# --- are included on the top-level cross-site GET back from the IdP.
+GET https://127.0.0.1:8443/
+Host: foo.bar
+HTTP 302
+[Asserts]
+header "Location" contains "http://mock-oauth2.auth:8080/entraid/authorize"
+cookie "OauthNonce[SameSite]"   == "Lax"
+cookie "CodeVerifier[SameSite]" == "Lax"
+# --- Sanity: the cookies must also be HttpOnly to prevent JS access.
+cookie "OauthNonce[HttpOnly]"   exists
+cookie "CodeVerifier[HttpOnly]" exists
+
+# --- Authenticated request with only a RefreshToken cookie forces Envoy to use
+# --- the refresh_token grant to mint a new access token. On success it sets
+# --- new session cookies (BearerToken, IdToken, OauthHMAC, OauthExpires, and
+# --- a rotated RefreshToken). Each of these must also be SameSite=Lax.
+GET https://127.0.0.1:8443/
+Host: foo.bar
+[Cookies]
+RefreshToken: {{entraid_refresh_token}}
+HTTP 200
+[Asserts]
+cookie "BearerToken[SameSite]"   == "Lax"
+cookie "IdToken[SameSite]"       == "Lax"
+cookie "OauthHMAC[SameSite]"     == "Lax"
+cookie "OauthExpires[SameSite]"  == "Lax"
+cookie "RefreshToken[SameSite]"  == "Lax"


### PR DESCRIPTION
## Checklist
- [x] Commits follow best practice git conventions
- [x] Introduced dependencies are reviewed
- [x] Test coverage is adequate
- [x] New features are documented on `skip.kartverket.no`
- [x] Changes to CRD are documented on `skip.kartverket.no`
- [x] Changes are supported by the `skip-ztoperator` copilot skill
- [x] `setup-skip-action` and `test-authpolicy-action` are compatible with changes
- [x] Code in this PR was written using AI assistance

## Description
Older browsers do not default to a strict enough SameSite behaviour, so we set it explicitly to mitigate CSRF and cross-site cookie leakage.

SameSite=Lax is used because the OAuth2 Authorization Code Flow relies on a top-level cross-site redirect from the IdP back to the application's redirect_uri. With SameSite=Strict, cookies set before the redirect (notably OauthNonce and CodeVerifier) would not be sent on the callback, breaking the code exchange. The seven cookie configs set are defined in the envoyproxy documentation.

This may affect existing users if:

- They use an old browser, mostly pre-2020

- They use ztoperator to protect something that is embedded cross-site.
  I haven't heard about anyone using ztoperator in this way at
  Kartverket

If the Lua filter is ever modified to set cookies, these should also have an appropriate SameSite value (for instance Lax).