### PR TITLE
test(controller): add reconcile resolve-failure test

### DIFF
--- a/internal/controller/authpolicy_controller_reconcile_test.go
+++ b/internal/controller/authpolicy_controller_reconcile_test.go
@@ -2,6 +2,7 @@ package controller_test
 
 import (
 	"context"
+	"errors"
 
 	ztoperatorv1alpha1 "github.com/kartverket/ztoperator/api/v1alpha1"
 	"github.com/kartverket/ztoperator/internal/controller"
@@ -148,6 +149,40 @@ var _ = Describe("AuthPolicy Controller Reconcile", func() {
 			Expect(updatedPolicy.Status.Phase).To(Equal(ztoperatorv1alpha1.PhaseReady))
 			Expect(updatedPolicy.Status.Ready).To(BeTrue())
 			Expect(updatedPolicy.Status.ObservedGeneration).To(Equal(int64(1)))
+		})
+	})
+
+	Context("when the discovery document resolver returns an error", func() {
+		It("returns the error, sets status to Failed, and does not create child resources", func() {
+			By("configuring the resolver to return an error")
+			resolveErr := errors.New("discovery resolver failed")
+			reconciler.DiscoveryDocumentResolver = &fakeDiscoveryDocumentResolver{err: resolveErr}
+
+			By("reconciling the AuthPolicy")
+			result, err := reconciler.Reconcile(testCtx, ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: appName, Namespace: namespace},
+			})
+			Expect(err).To(MatchError(ContainSubstring(resolveErr.Error())))
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			By("verifying status is set to Failed")
+			updatedPolicy := &ztoperatorv1alpha1.AuthPolicy{}
+			Expect(fakeClient.Get(testCtx, types.NamespacedName{Name: appName, Namespace: namespace}, updatedPolicy)).To(Succeed())
+			Expect(updatedPolicy.Status.Phase).To(Equal(ztoperatorv1alpha1.PhaseFailed))
+			Expect(updatedPolicy.Status.Ready).To(BeFalse())
+			Expect(updatedPolicy.Status.Message).To(ContainSubstring(resolveErr.Error()))
+			Expect(updatedPolicy.Status.ObservedGeneration).To(Equal(int64(1)))
+
+			By("verifying no child resources were created")
+			ra := &securityv1.RequestAuthentication{}
+			Expect(apierrors.IsNotFound(
+				fakeClient.Get(testCtx, types.NamespacedName{Name: appName, Namespace: namespace}, ra),
+			)).To(BeTrue())
+
+			requirePolicy := &securityv1.AuthorizationPolicy{}
+			Expect(apierrors.IsNotFound(
+				fakeClient.Get(testCtx, types.NamespacedName{Name: names.RequirePolicy(appName), Namespace: namespace}, requirePolicy),
+			)).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
Tests the scenario where the discovery document resolver returns an error during reconciliation. Verifies that:
- Reconcile() returns the error
- AuthPolicy.status.phase is set to Failed
- AuthPolicy.status.message contains the error details
- AuthPolicy.status.ready is false
- AuthPolicy.status.observedGeneration is updated
- No child resources are created when resolve fails (early return before doReconcile)

Uses Ginkgo/Gomega with By() annotations for step clarity, following the established controller test pattern.

Not yet tested (next PR):
- Child resource reconciliation failures in doReconcile()
- Status update failures in the resolve-fail path
- Invalid config scenarios (validation errors)
- Event recording for resolve failures

## Checklist
- [x] Commits follow best practice git conventions
- [ ] Introduced dependencies are reviewed
- [ ] Test coverage is adequate
- [ ] New features are documented on `skip.kartverket.no`
- [ ] Changes to CRD are documented on `skip.kartverket.no`
- [ ] Changes are supported by the `skip-ztoperator` copilot skill
- [x] `setup-skip-action` and `test-authpolicy-action` are compatible with changes
- [x] Code in this PR was written using AI assistance

## Description
