### PR TITLE
fix(authpolicy): forbid oAuthCredentials without autoLogin

### DIFF
--- a/api/v1alpha1/authpolicy_types.go
+++ b/api/v1alpha1/authpolicy_types.go
@@ -8,6 +8,7 @@ import (
 //
 // +kubebuilder:validation:XValidation:message="acceptedResources must be non-empty when using Ansattporten or ID-Porten",rule="!(self.wellKnownURI in ['https://test.idporten.no/.well-known/openid-configuration', 'https://idporten.no/.well-known/openid-configuration', 'https://test.ansattporten.no/.well-known/openid-configuration', 'https://ansattporten.no/.well-known/openid-configuration']) || (has(self.acceptedResources) && self.acceptedResources.size() > 0)"
 // +kubebuilder:validation:XValidation:message="oAuthCredentials must be set when autoLogin is enabled",rule="!has(self.autoLogin) || !self.autoLogin.enabled || has(self.oAuthCredentials)"
+// +kubebuilder:validation:XValidation:message="oAuthCredentials cannot be set unless autoLogin is configured",rule="!has(self.oAuthCredentials) || has(self.autoLogin)"
 type AuthPolicySpec struct {
 	// Whether to enable JWT validation.
 	// If enabled, incoming JWTs will be validated against the issuer specified in the app registration and the generated audience.

--- a/config/crd/bases/ztoperator.kartverket.no_authpolicies.yaml
+++ b/config/crd/bases/ztoperator.kartverket.no_authpolicies.yaml
@@ -467,6 +467,8 @@ spec:
                 (has(self.acceptedResources) && self.acceptedResources.size() > 0)'
             - message: oAuthCredentials must be set when autoLogin is enabled
               rule: '!has(self.autoLogin) || !self.autoLogin.enabled || has(self.oAuthCredentials)'
+            - message: oAuthCredentials cannot be set unless autoLogin is configured
+              rule: '!has(self.oAuthCredentials) || has(self.autoLogin)'
           status:
             description: AuthPolicyStatus defines the observed state of AuthPolicy.
             properties:

--- a/test/chainsaw/authpolicy/manifest-validation/autologin/authpolicy-without-autologin.yaml
+++ b/test/chainsaw/authpolicy/manifest-validation/autologin/authpolicy-without-autologin.yaml
@@ -1,0 +1,15 @@
+apiVersion: ztoperator.kartverket.no/v1alpha1
+kind: AuthPolicy
+metadata:
+  name: auth-policy
+spec:
+  enabled: true
+  wellKnownURI: http://mock-oauth2.auth:8080/entraid/.well-known/openid-configuration
+  oAuthCredentials:
+    secretRef: oauth-secret
+    clientIDKey: client-id
+    clientSecretKey: client-secret
+  selector:
+    matchLabels:
+      app: application
+

--- a/test/chainsaw/authpolicy/manifest-validation/autologin/patch-without-autologin.yaml
+++ b/test/chainsaw/authpolicy/manifest-validation/autologin/patch-without-autologin.yaml
@@ -1,0 +1,7 @@
+spec:
+  oAuthCredentials:
+    secretRef: oauth-secret
+    clientIDKey: client-id
+    clientSecretKey: client-secret
+  autoLogin: null
+

--- a/test/chainsaw/authpolicy/manifest-validation/chainsaw-test.yaml
+++ b/test/chainsaw/authpolicy/manifest-validation/chainsaw-test.yaml
@@ -64,6 +64,10 @@ spec:
                 "oAuthCredentials must be set when autoLogin is enabled"
 
               ./../../../../scripts/patch-invalid-spec.sh \
+                autologin/patch-without-autologin.yaml \
+                "oAuthCredentials cannot be set unless autoLogin is configured"
+
+              ./../../../../scripts/patch-invalid-spec.sh \
                 autologin/patch-invalid-login-param-key.yaml \
                 "loginParams keys must match ^[a-zA-Z_][a-zA-Z0-9_]*$"
         - script: # AutoLogin - replace
@@ -71,6 +75,10 @@ spec:
               ./../../../../scripts/replace-invalid-spec.sh \
                 autologin/authpolicy-without-oauthcredentials.yaml \
                 "oAuthCredentials must be set when autoLogin is enabled"
+
+              ./../../../../scripts/replace-invalid-spec.sh \
+                autologin/authpolicy-without-autologin.yaml \
+                "oAuthCredentials cannot be set unless autoLogin is configured"
         - delete:
             file: autologin/authpolicy.yaml
 


### PR DESCRIPTION
Add XValidation so AuthPolicy cannot configure oAuthCredentials unless autoLogin is enabled. Cover the rule in manifest-validation Chainsaw tests and regenerate the CRD.

## Checklist
- [x] Commits follow best practice git conventions
- [ ] Introduced dependencies are reviewed
- [ ] Test coverage is adequate
- [ ] New features are documented on `skip.kartverket.no`
- [ ] Changes to CRD are documented on `skip.kartverket.no`
- [ ] Changes are supported by the `skip-ztoperator` copilot skill
- [x] `setup-skip-action` and `test-authpolicy-action` are compatible with changes
- [x] Code in this PR was written using AI assistance

## Description
